### PR TITLE
Automatically generate SSH key without any user input

### DIFF
--- a/src/commands/createVirtualMachine/VirtualMachineCreateStep.ts
+++ b/src/commands/createVirtualMachine/VirtualMachineCreateStep.ts
@@ -5,6 +5,7 @@
 
 import { ComputeManagementClient, ComputeManagementModels } from 'azure-arm-compute';
 import { NetworkManagementModels } from 'azure-arm-network';
+import { posix } from 'path';
 import { Progress } from "vscode";
 import { AzureWizardExecuteStep, createAzureClient } from "vscode-azureextensionui";
 import { localize } from '../../localize';
@@ -36,9 +37,9 @@ export class VirtualMachineCreateStep extends AzureWizardExecuteStep<IVirtualMac
         const linuxConfiguration: ComputeManagementModels.LinuxConfiguration = {
             disablePasswordAuthentication: true, ssh: {
                 publicKeys: [{
-                    keyData: await getSshKey(),
+                    keyData: await getSshKey(vmName),
                     // because this is a Linux VM, use '/' as path separator rather than using path.join()
-                    path: `/home/${context.adminUsername}/.ssh/authorized_keys`
+                    path: posix.join('home', context.adminUsername, '.ssh', 'authorized_keys')
                 }]
             }
         };

--- a/src/commands/getSshKey.ts
+++ b/src/commands/getSshKey.ts
@@ -9,7 +9,7 @@ import { IParsedError, parseError } from "vscode-azureextensionui";
 import { cpUtils } from "../utils/cpUtils";
 
 export async function getSshKey(vmName: string): Promise<string> {
-    const sshKeyName: string = `Azure_${vmName}_rsa`;
+    const sshKeyName: string = `azure_${vmName}_rsa`;
     const sshKeyPath: string = join(os.homedir(), '.ssh', sshKeyName);
     const doesntExistError: string = 'No such file or directory';
 


### PR DESCRIPTION
Before I had those nasty delays to hit "Return" for the user, but I've found different parameters that can be used to bypass all that.

After discussing with @fiveisprime we thought it made more sense to have the pub key to be named after the Azure VM rather than just using the generic id_rsa file.