### PR TITLE
Change the order of nsg and ni

### DIFF
--- a/src/commands/createVirtualMachine/NetworkInterfaceCreateStep.ts
+++ b/src/commands/createVirtualMachine/NetworkInterfaceCreateStep.ts
@@ -12,7 +12,7 @@ import { nonNullProp, nonNullValueAndProp } from '../../utils/nonNull';
 import { IVirtualMachineWizardContext } from './IVirtualMachineWizardContext';
 
 export class NetworkInterfaceCreateStep extends AzureWizardExecuteStep<IVirtualMachineWizardContext> {
-    public priority: number = 240;
+    public priority: number = 250;
 
     public async execute(context: IVirtualMachineWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const networkClient: NetworkManagementClient = createAzureClient(context, NetworkManagementClient);
@@ -26,7 +26,7 @@ export class NetworkInterfaceCreateStep extends AzureWizardExecuteStep<IVirtualM
         const subnet: NetworkManagementModels.Subnet = nonNullProp(context, 'subnet');
 
         const networkInterfaceProps: NetworkManagementModels.NetworkInterface = {
-            location, ipConfigurations: [{ name: context.newNetworkInterfaceName, publicIPAddress: publicIpAddress, subnet: subnet }]
+            location, networkSecurityGroup: context.networkSecurityGroup, ipConfigurations: [{ name: context.newNetworkInterfaceName, publicIPAddress: publicIpAddress, subnet: subnet }]
         };
 
         const creatingNi: string = localize('creatingNi', `Creating new network interface "${context.newNetworkInterfaceName}"...`);

--- a/src/commands/createVirtualMachine/NetworkSecurityGroupCreateStep.ts
+++ b/src/commands/createVirtualMachine/NetworkSecurityGroupCreateStep.ts
@@ -12,7 +12,7 @@ import { nonNullProp, nonNullValueAndProp } from '../../utils/nonNull';
 import { IVirtualMachineWizardContext } from './IVirtualMachineWizardContext';
 
 export class NetworkSecurityGroupCreateStep extends AzureWizardExecuteStep<IVirtualMachineWizardContext> {
-    public priority: number = 250;
+    public priority: number = 240;
 
     public async execute(context: IVirtualMachineWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const networkClient: NetworkManagementClient = createAzureClient(context, NetworkManagementClient);
@@ -20,15 +20,13 @@ export class NetworkSecurityGroupCreateStep extends AzureWizardExecuteStep<IVirt
 
         // when creating a VM on the portal, this is the suffix that is added to the network security group
         const nsgName: string = nonNullProp(context, 'newVirtualMachineName') + '-nsg';
-        const networkInterface: NetworkManagementModels.NetworkInterface = nonNullProp(context, 'networkInterface');
 
         const networkSecurityGroupProps: NetworkManagementModels.NetworkSecurityGroup = {
             name: nsgName, location, securityRules: [
                 { name: 'SSH', protocol: 'TCP', sourcePortRange: '*', destinationPortRange: '22', sourceAddressPrefix: '*', destinationAddressPrefix: '*', access: 'Allow', priority: 340, direction: 'Inbound' },
                 { name: 'HTTPS', protocol: 'TCP', sourcePortRange: '*', destinationPortRange: '443', sourceAddressPrefix: '*', destinationAddressPrefix: '*', access: 'Allow', priority: 320, direction: 'Inbound' },
                 { name: 'HTTP', protocol: 'TCP', sourcePortRange: '*', destinationPortRange: '80', sourceAddressPrefix: '*', destinationAddressPrefix: '*', access: 'Allow', priority: 300, direction: 'Inbound' }
-            ],
-            networkInterfaces: [networkInterface]
+            ]
         };
 
         const creatingNsg: string = localize('creatingNsg', `Creating new network security group "${nsgName}"...`);

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -83,8 +83,8 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         executeSteps.push(new PublicIpCreateStep());
         executeSteps.push(new VirtualNetworkCreateStep());
         executeSteps.push(new SubnetCreateStep());
-        executeSteps.push(new NetworkInterfaceCreateStep());
         executeSteps.push(new NetworkSecurityGroupCreateStep());
+        executeSteps.push(new NetworkInterfaceCreateStep());
         executeSteps.push(new VirtualMachineCreateStep());
 
         const title: string = 'Create new virtual machine';


### PR DESCRIPTION
I originally made the NetworkInterface first, and then included the interface to the NetworkSecurityGroup after that, but it doesn't seem like it was actually connecting the two resources together.

This changes it to create the nsg first, and then attach the nsg to the interface.