### PR TITLE
Fix output related issues

### DIFF
--- a/src/commands/addSshKey.ts
+++ b/src/commands/addSshKey.ts
@@ -42,14 +42,14 @@ export async function addSshKey(context: IActionContext, node?: VirtualMachineTr
         };
     }
 
-    const configuringSsh: string = localize('ConfiguringSsh', 'Configuring virtual machine "{0}" with SSH Public Key "{1}"...', node.name, sshPublicKey.fsPath);
-    const configuringSshSucceeded: string = localize('ConfiguringSshSucceeded', 'Successfully configured "{0}".', node.name);
+    const addingSshKey: string = localize('addingSshKey', 'Adding SSH Public Key "{0}" to Azure VM "{1}" ...', sshPublicKey.fsPath, node.name);
+    const addingSshKeySucceeded: string = localize('addingSshKeySucceeded', 'Successfully added key to "{0}".', node.name);
 
-    await window.withProgress({ location: ProgressLocation.Notification, title: configuringSsh }, async (): Promise<void> => {
-        ext.outputChannel.appendLog(configuringSsh);
+    await window.withProgress({ location: ProgressLocation.Notification, title: addingSshKey }, async (): Promise<void> => {
+        ext.outputChannel.appendLog(addingSshKey);
         await computeClient.virtualMachineExtensions.createOrUpdate(nonNullValueAndProp(node, 'resourceGroup'), nonNullValueAndProp(node, 'name'), extensionName, vmExtension);
-        window.showInformationMessage(configuringSshSucceeded);
-        ext.outputChannel.appendLog(configuringSshSucceeded);
+        window.showInformationMessage(addingSshKeySucceeded);
+        ext.outputChannel.appendLog(addingSshKeySucceeded);
     });
 
     // the ssh/config file lists the private key, not the .pub file, so remove the ext from the file path

--- a/src/commands/createVirtualMachine/VirtualMachineCreateStep.ts
+++ b/src/commands/createVirtualMachine/VirtualMachineCreateStep.ts
@@ -50,10 +50,17 @@ export class VirtualMachineCreateStep extends AzureWizardExecuteStep<IVirtualMac
 
         const rgName: string = nonNullValueAndProp(context.resourceGroup, 'name');
 
-        const creatingVm: string = localize('creatingVm', `Creating new virtual machine "${vmName}"...`);
-        const createdVm: string = localize('creatingVm', `Created new virtual machine "${vmName}".`);
+        const creatingVm: string = localize('creatingVm', 'Creating new virtual machine "{0}"...', vmName);
+        const creatingVmDetails: string = localize(
+            'creatingVmDetails',
+            'Creating new virtual "{0}" with size "{1}" and image "{2}"',
+            vmName,
+            nonNullProp(hardwareProfile, 'vmSize').replace(/_/g, ' '), // sizes are written with underscores as spaces
+            `${nonNullProp(storageProfile, 'imageReference').offer} ${nonNullProp(storageProfile, 'imageReference').sku}`);
 
-        ext.outputChannel.appendLog(creatingVm);
+        const createdVm: string = localize('creatingVm', 'Created new virtual machine "{0}"...', vmName);
+
+        ext.outputChannel.appendLog(creatingVmDetails);
         progress.report({ message: creatingVm });
         context.virtualMachine = await computeClient.virtualMachines.createOrUpdate(rgName, vmName, virtualMachineProps);
         ext.outputChannel.appendLog(createdVm);


### PR DESCRIPTION
Tutorials call it "Adding an SSH key" https://code.visualstudio.com/remote-tutorials/ssh/add-ssh-key so I changed the cmd/output to follow suit.

Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/51 Added a view output button and added a notification when VM is finished creating.

Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/13 The display name for the Image is super unfriendly.  I looked into it, and the Portal uses a beta GET request that I'm not sure how to access to get the display name and ResourceGraph for all of the others. 

![image](https://user-images.githubusercontent.com/5290572/75208366-4d96da00-5730-11ea-80b5-a7cc654c3150.png)

This is how I'm parsing it now.  I don't think it's ideal, but it's readable enough IMO.  I've spent an hour looking through API calls and don't feel like it's worth the effort right now.

![image](https://user-images.githubusercontent.com/5290572/75208429-78812e00-5730-11ea-9855-738a978ef42f.png)
