### PR TITLE
Show other VM statuses

### DIFF
--- a/src/commands/stopVirtualMachine.ts
+++ b/src/commands/stopVirtualMachine.ts
@@ -16,14 +16,14 @@ export async function stopVirtualMachine(context: IActionContext, node?: Virtual
     }
 
     const computeClient: ComputeManagementClient = createAzureClient(node.root, ComputeManagementClient);
-    const stoppingVm: string = localize('stoppingVm', `Deallocating "${node.name}"...`);
-    const stoppedVm: string = localize('stoppedVm', `"${node.name}" has been deallocated.`);
+    const deallocatingVm: string = localize('deallocatingVm', `Deallocating "${node.name}"...`);
+    const deallocatedVm: string = localize('deallocatedVm', `"${node.name}" has been deallocated.`);
 
-    await node.runWithTemporaryDescription(localize('stopping', 'Deallocating...'), async () => {
+    await node.runWithTemporaryDescription(localize('deallocating', 'Deallocating...'), async () => {
         const vmti: VirtualMachineTreeItem = nonNullValue(node);
-        ext.outputChannel.appendLog(stoppingVm);
+        ext.outputChannel.appendLog(deallocatingVm);
         await computeClient.virtualMachines.deallocate(vmti.resourceGroup, vmti.name);
-        ext.outputChannel.appendLog(stoppedVm);
+        ext.outputChannel.appendLog(deallocatedVm);
     });
 
 }

--- a/src/commands/stopVirtualMachine.ts
+++ b/src/commands/stopVirtualMachine.ts
@@ -16,10 +16,10 @@ export async function stopVirtualMachine(context: IActionContext, node?: Virtual
     }
 
     const computeClient: ComputeManagementClient = createAzureClient(node.root, ComputeManagementClient);
-    const stoppingVm: string = localize('stoppingVm', `Stopping "${node.name}"...`);
-    const stoppedVm: string = localize('stoppedVm', `"${node.name}" has been stopped.`);
+    const stoppingVm: string = localize('stoppingVm', `Deallocating "${node.name}"...`);
+    const stoppedVm: string = localize('stoppedVm', `"${node.name}" has been deallocated.`);
 
-    await node.runWithTemporaryDescription(localize('stopping', 'Stopping...'), async () => {
+    await node.runWithTemporaryDescription(localize('stopping', 'Deallocating...'), async () => {
         const vmti: VirtualMachineTreeItem = nonNullValue(node);
         ext.outputChannel.appendLog(stoppingVm);
         await computeClient.virtualMachines.deallocate(vmti.resourceGroup, vmti.name);

--- a/src/tree/VirtualMachineTreeItem.ts
+++ b/src/tree/VirtualMachineTreeItem.ts
@@ -35,7 +35,7 @@ export class VirtualMachineTreeItem extends AzureTreeItem {
     }
 
     public get description(): string | undefined {
-        return this._state && this._state.toLowerCase().includes('deallocated') ? 'Stopped' : undefined;
+        return this._state !== 'running' ? this._state : undefined;
     }
 
     public static contextValue: string = 'azVmVirtualMachine';
@@ -106,6 +106,6 @@ export class VirtualMachineTreeItem extends AzureTreeItem {
 
     private getStateFromInstanceView(instanceView: ComputeManagementModels.VirtualMachineInstanceView): string | undefined {
         const powerState: ComputeManagementModels.InstanceViewStatus | undefined = instanceView.statuses && instanceView.statuses.find((status): boolean => status.code && status.code.toLowerCase().includes('powerstate') ? true : false);
-        return powerState ? powerState.displayStatus : undefined;
+        return powerState && powerState.displayStatus ? powerState.displayStatus.replace(/vm/i, '').trim() : undefined;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/38

So the verb they use in the response is "deallocate" so I'm using that as well.

Also, when you stop, the temp. the description doesn't quite match the vm description, but I personally prefer it like this since it has the loading indicator.

![image](https://user-images.githubusercontent.com/5290572/75211304-64412f00-5738-11ea-8fd2-77dec33286c3.png)

I'm keeping the command as "Stop" since that's the verbiage the portal uses as well.

![image](https://user-images.githubusercontent.com/5290572/75211377-8b97fc00-5738-11ea-896d-9f5e2f24a1d8.png)
