### PR TITLE
Associate NSG to subnet rather than interface

### DIFF
--- a/src/commands/createVirtualMachine/NetworkInterfaceCreateStep.ts
+++ b/src/commands/createVirtualMachine/NetworkInterfaceCreateStep.ts
@@ -26,7 +26,7 @@ export class NetworkInterfaceCreateStep extends AzureWizardExecuteStep<IVirtualM
         const subnet: NetworkManagementModels.Subnet = nonNullProp(context, 'subnet');
 
         const networkInterfaceProps: NetworkManagementModels.NetworkInterface = {
-            location, networkSecurityGroup: context.networkSecurityGroup, ipConfigurations: [{ name: context.newNetworkInterfaceName, publicIPAddress: publicIpAddress, subnet: subnet }]
+            location, ipConfigurations: [{ name: context.newNetworkInterfaceName, publicIPAddress: publicIpAddress, subnet: subnet }]
         };
 
         const creatingNi: string = localize('creatingNi', `Creating new network interface "${context.newNetworkInterfaceName}"...`);

--- a/src/commands/createVirtualMachine/NetworkSecurityGroupCreateStep.ts
+++ b/src/commands/createVirtualMachine/NetworkSecurityGroupCreateStep.ts
@@ -12,7 +12,7 @@ import { nonNullProp, nonNullValueAndProp } from '../../utils/nonNull';
 import { IVirtualMachineWizardContext } from './IVirtualMachineWizardContext';
 
 export class NetworkSecurityGroupCreateStep extends AzureWizardExecuteStep<IVirtualMachineWizardContext> {
-    public priority: number = 240;
+    public priority: number = 220;
 
     public async execute(context: IVirtualMachineWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const networkClient: NetworkManagementClient = createAzureClient(context, NetworkManagementClient);

--- a/src/commands/createVirtualMachine/SubnetCreateStep.ts
+++ b/src/commands/createVirtualMachine/SubnetCreateStep.ts
@@ -12,7 +12,7 @@ import { nonNullProp, nonNullValueAndProp } from '../../utils/nonNull';
 import { IVirtualMachineWizardContext } from './IVirtualMachineWizardContext';
 
 export class SubnetCreateStep extends AzureWizardExecuteStep<IVirtualMachineWizardContext> {
-    public priority: number = 230;
+    public priority: number = 240;
 
     public async execute(context: IVirtualMachineWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const networkClient: NetworkManagementClient = createAzureClient(context, NetworkManagementClient);
@@ -23,7 +23,7 @@ export class SubnetCreateStep extends AzureWizardExecuteStep<IVirtualMachineWiza
         const subnetName: string = 'default';
 
         const creatingSubnet: string = localize('creatingSubnet', `Creating new subnet "${subnetName}"...`);
-        const subnetProps: NetworkManagementModels.Subnet = { addressPrefix: nonNullProp(context, 'addressPrefix'), name: subnetName };
+        const subnetProps: NetworkManagementModels.Subnet = { addressPrefix: nonNullProp(context, 'addressPrefix'), name: subnetName, networkSecurityGroup: context.networkSecurityGroup };
 
         progress.report({ message: creatingSubnet });
         ext.outputChannel.appendLog(creatingSubnet);

--- a/src/commands/createVirtualMachine/VirtualNetworkCreateStep.ts
+++ b/src/commands/createVirtualMachine/VirtualNetworkCreateStep.ts
@@ -12,7 +12,7 @@ import { nonNullProp, nonNullValueAndProp } from '../../utils/nonNull';
 import { IVirtualMachineWizardContext } from './IVirtualMachineWizardContext';
 
 export class VirtualNetworkCreateStep extends AzureWizardExecuteStep<IVirtualMachineWizardContext> {
-    public priority: number = 220;
+    public priority: number = 230;
 
     public async execute(context: IVirtualMachineWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const networkClient: NetworkManagementClient = createAzureClient(context, NetworkManagementClient);


### PR DESCRIPTION
According to this http://stbitkb/index.php?/article/AA-01300/97/, it's the preferred method despite the Portal attaching the NSG to the Interface.  This makes the NSG apply to all VMs that use this VNet/subnet.

I did a quick test and the subnet is associated with the NSG in the Portal and the SSHing still seems to work.