### PR TITLE
Remove duplicate HostName check

### DIFF
--- a/src/utils/sshUtils.ts
+++ b/src/utils/sshUtils.ts
@@ -30,11 +30,7 @@ export async function configureSshConfig(vmti: VirtualMachineTreeItem, sshKeyPat
     await fse.ensureFile(sshConfigPath);
     let configFile: string = (await fse.readFile(sshConfigPath)).toString();
 
-    // look to see if the hostname already exists (the same ip address)
-
-    // HostName is the only thing that's unique so if we find a copy, prompt the user to use that profile instead
     // If we find duplicate Hosts, we can just make a new entry called Host (2)...(3)...etc
-
     const hostName: string = await vmti.getHostName();
     let host: string = vmti.name;
 

--- a/src/utils/sshUtils.ts
+++ b/src/utils/sshUtils.ts
@@ -38,11 +38,7 @@ export async function configureSshConfig(vmti: VirtualMachineTreeItem, sshKeyPat
     const hostName: string = await vmti.getHostName();
     let host: string = vmti.name;
 
-    if (configFile.includes(`HostName ${hostName}`)) {
-        // tslint:disable-next-line: no-floating-promises
-        ext.ui.showWarningMessage(`HostName "${hostName}" already exists. Use that profile to connect via SSH.`);
-        return;
-    } else if (configFile.includes(`Host ${vmti.name}`)) {
+    if (configFile.includes(`Host ${vmti.name}`)) {
         // tslint:disable-next-line: no-floating-promises
         ext.ui.showWarningMessage(`Host "${host}" already exists in SSH config.  Creating a copy of the host.`);
         let count: number = 2;


### PR DESCRIPTION
As far as I can tell, having a duplicate HostName entry doesn't cause any issues besides clutter.  That being said, it's been causing issues because when you `Add a SSH Key...` it won't add the new entry with the new `IdentityFile` to the `config` file since the `HostName` already exists.  This seems like it'd be a common scenario if users create the VM in our extension in the first place.

It feels more useful to just make sure the `Host` (the display name) is unique, but not worry about duplicate `HostName`s.

This would make this issue https://github.com/microsoft/vscode-azurevirtualmachines/issues/14 irrelevant as well, and we could close it.

Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/14