### PR TITLE
Fix linux tests

### DIFF
--- a/.azure-pipelines/linux/xvfb.init
+++ b/.azure-pipelines/linux/xvfb.init
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# COPIED FROM https://github.com/Microsoft/vscode/blob/e29c517386fe6f3a40e2f0ff00effae4919406aa/build/tfs/linux/x64/xvfb.init
+# COPIED FROM https://github.com/microsoft/vscode/blob/01e9903967417ba243cec705445eef9ecbfebfea/build/azure-pipelines/linux/xvfb.init
 #
 #
 # /etc/rc.d/init.d/xvfbd
@@ -22,7 +22,7 @@
 [ "${NETWORKING}" = "no" ] && exit 0
 
 PROG="/usr/bin/Xvfb"
-PROG_OPTIONS=":10 -ac"
+PROG_OPTIONS=":10 -ac -screen 0 1024x768x24"
 PROG_OUTPUT="/tmp/Xvfb.out"
 
 case "$1" in


### PR DESCRIPTION
I know there aren't tests yet, but it bugs me that the dev ops build has a warning for linux:
![Screen Shot 2020-02-26 at 11 54 30 AM](https://user-images.githubusercontent.com/11282622/75382150-c9a73400-588e-11ea-946b-5c749b335b02.png)

Same fix as https://github.com/microsoft/vscode-azureappservice/pull/1391