### PR TITLE
Add Advanced Create to select image 🖼 of VM 🖥

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "onCommand:azureVirtualMachines.refresh",
         "onCommand:azureVirtualMachines.loadMore",
         "azureVirtualMachines.createVirtualMachine",
+        "azureVirtualMachines.createVirtualMachineAdvanced",
         "azureVirtualMachines.startVirtualMachine",
         "azureVirtualMachines.stopVirtualMachine",
         "azureVirtualMachines.addSshKey",
@@ -78,6 +79,11 @@
                     "light": "resources/light/createVM.svg",
                     "dark": "resources/dark/createVM.svg"
                 }
+            },
+            {
+                "command": "azureVirtualMachines.createVirtualMachineAdvanced",
+                "title": "%azureVirtualMachines.createVirtualMachineAdvanced%",
+                "category": "Azure Virtual Machines"
             },
             {
                 "command": "azureVirtualMachines.startVirtualMachine",
@@ -145,6 +151,11 @@
                     "command": "azureVirtualMachines.createVirtualMachine",
                     "when": "view == azVmTree && viewItem == azureextensionui.azureSubscription",
                     "group": "1@1"
+                },
+                {
+                    "command": "azureVirtualMachines.createVirtualMachineAdvanced",
+                    "when": "view == azVmTree && viewItem == azureextensionui.azureSubscription",
+                    "group": "1@2"
                 },
                 {
                     "command": "azureVirtualMachines.openInPortal",

--- a/package.nls.json
+++ b/package.nls.json
@@ -3,6 +3,7 @@
     "azureVirtualMachines.refresh": "Refresh",
     "azureVirtualMachines.loadMore": "Load More",
     "azureVirtualMachines.createVirtualMachine": "Create Virtual Machine...",
+    "azureVirtualMachines.createVirtualMachineAdvanced": "Create Virtual Machine... (Advanced)",
     "azureVirtualMachines.openInPortal": "Open in Portal",
     "azureVirtualMachines.startVirtualMachine": "Start",
     "azureVirtualMachines.stopVirtualMachine": "Stop",

--- a/src/commands/createVirtualMachine/ImageListStep.ts
+++ b/src/commands/createVirtualMachine/ImageListStep.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ComputeManagementModels } from '@azure/arm-compute';
+import { AzureWizardPromptStep } from "vscode-azureextensionui";
+import { ext } from '../../extensionVariables';
+import { localize } from '../../localize';
+import { IVirtualMachineWizardContext } from './IVirtualMachineWizardContext';
+
+type ImageReferenceWithLabel = ComputeManagementModels.ImageReference & { label: string };
+
+export class ImageListStep extends AzureWizardPromptStep<IVirtualMachineWizardContext> {
+
+    public async prompt(context: IVirtualMachineWizardContext): Promise<void> {
+        const placeHolder: string = localize('selectImage', 'Select an image');
+        context.image = (await ext.ui.showQuickPick(this.getAvailableImages().map((ir) => { return { label: ir.label, data: ir }; }), {
+            placeHolder
+        })).data;
+    }
+
+    public shouldPrompt(context: IVirtualMachineWizardContext): boolean {
+        return !context.image;
+    }
+
+    private getAvailableImages(): ImageReferenceWithLabel[] {
+        return [
+            {
+                label: 'Ubuntu Server 18.04 LTS - Gen1',
+                publisher: 'Canonical',
+                offer: 'UbuntuServer',
+                sku: '18.04-LTS',
+                version: 'latest',
+                exactVersion: '18.04.202007290'
+            },
+            {
+                label: 'Red Hat Enterprise Linux 8.2 (LVM) - Gen1',
+                publisher: 'RedHat',
+                offer: 'RHEL',
+                sku: '8.2',
+                version: 'latest',
+                exactVersion: '8.2.2020050811'
+            },
+            {
+                label: 'SUSE Enterprise Linux 15 SP1 - Gen1',
+                publisher: 'suse',
+                offer: 'sles-15-sp1-basic',
+                sku: 'gen1',
+                version: 'latest',
+                exactVersion: '2020.06.10'
+            },
+            {
+                label: 'CentOS-based 8.2 - Gen1',
+                publisher: 'OpenLogic',
+                offer: 'CentOS',
+                sku: '8_2',
+                version: 'latest',
+                exactVersion: '8.2.2020062400'
+            },
+            {
+                label: 'Debian 10 "Buster" - Gen1',
+                publisher: 'debian',
+                offer: 'debian-10',
+                sku: '10',
+                version: 'latest',
+                exactVersion: '0.20200803.347'
+            },
+            {
+                label: 'Oracle Linux 7.8 - Gen1',
+                publisher: 'Oracle',
+                offer: 'Oracle-Linux',
+                sku: '78',
+                version: 'latest',
+                exactVersion: '7.8.3'
+            },
+            {
+                label: 'Ubuntu Server 16.04 LTS - Gen1',
+                publisher: 'Canonical',
+                offer: 'UbuntuServer',
+                sku: '16.04-LTS',
+                version: 'latest',
+                exactVersion: '16.04.202007290'
+            },
+            {
+                label: 'Data Science Virtual Machine - Ubuntu 18.04 - Gen1',
+                publisher: 'microsoft-dsvm',
+                offer: 'ubuntu-1804',
+                sku: '1804',
+                version: 'latest',
+                exactVersion: '20.07.06'
+            }
+        ];
+    }
+}

--- a/src/commands/createVirtualMachine/ImageListStep.ts
+++ b/src/commands/createVirtualMachine/ImageListStep.ts
@@ -24,71 +24,63 @@ export class ImageListStep extends AzureWizardPromptStep<IVirtualMachineWizardCo
         return !context.image;
     }
 
-    private getAvailableImages(): ImageReferenceWithLabel[] {
+    public getAvailableImages(): ImageReferenceWithLabel[] {
         return [
             {
                 label: 'Ubuntu Server 18.04 LTS - Gen1',
                 publisher: 'Canonical',
                 offer: 'UbuntuServer',
                 sku: '18.04-LTS',
-                version: 'latest',
-                exactVersion: '18.04.202007290'
+                version: 'latest'
             },
             {
                 label: 'Red Hat Enterprise Linux 8.2 (LVM) - Gen1',
                 publisher: 'RedHat',
                 offer: 'RHEL',
                 sku: '8.2',
-                version: 'latest',
-                exactVersion: '8.2.2020050811'
+                version: 'latest'
             },
             {
                 label: 'SUSE Enterprise Linux 15 SP1 - Gen1',
                 publisher: 'suse',
                 offer: 'sles-15-sp1-basic',
                 sku: 'gen1',
-                version: 'latest',
-                exactVersion: '2020.06.10'
+                version: 'latest'
             },
             {
                 label: 'CentOS-based 8.2 - Gen1',
                 publisher: 'OpenLogic',
                 offer: 'CentOS',
                 sku: '8_2',
-                version: 'latest',
-                exactVersion: '8.2.2020062400'
+                version: 'latest'
             },
             {
                 label: 'Debian 10 "Buster" - Gen1',
                 publisher: 'debian',
                 offer: 'debian-10',
                 sku: '10',
-                version: 'latest',
-                exactVersion: '0.20200803.347'
+                version: 'latest'
             },
             {
                 label: 'Oracle Linux 7.8 - Gen1',
                 publisher: 'Oracle',
                 offer: 'Oracle-Linux',
                 sku: '78',
-                version: 'latest',
-                exactVersion: '7.8.3'
+                version: 'latest'
             },
             {
                 label: 'Ubuntu Server 16.04 LTS - Gen1',
                 publisher: 'Canonical',
                 offer: 'UbuntuServer',
                 sku: '16.04-LTS',
-                version: 'latest',
-                exactVersion: '16.04.202007290'
+                version: 'latest'
             },
             {
                 label: 'Data Science Virtual Machine - Ubuntu 18.04 - Gen1',
                 publisher: 'microsoft-dsvm',
                 offer: 'ubuntu-1804',
                 sku: '1804',
-                version: 'latest',
-                exactVersion: '20.07.06'
+                version: 'latest'
             }
         ];
     }

--- a/src/commands/createVirtualMachine/ImageListStep.ts
+++ b/src/commands/createVirtualMachine/ImageListStep.ts
@@ -11,6 +11,14 @@ import { IVirtualMachineWizardContext } from './IVirtualMachineWizardContext';
 
 type ImageReferenceWithLabel = ComputeManagementModels.ImageReference & { label: string };
 
+export const ubuntu1804LTSImage: ImageReferenceWithLabel = {
+    label: 'Ubuntu Server 18.04 LTS - Gen1',
+    publisher: 'Canonical',
+    offer: 'UbuntuServer',
+    sku: '18.04-LTS',
+    version: 'latest'
+};
+
 export class ImageListStep extends AzureWizardPromptStep<IVirtualMachineWizardContext> {
 
     public async prompt(context: IVirtualMachineWizardContext): Promise<void> {
@@ -24,15 +32,9 @@ export class ImageListStep extends AzureWizardPromptStep<IVirtualMachineWizardCo
         return !context.image;
     }
 
-    public getAvailableImages(): ImageReferenceWithLabel[] {
+    private getAvailableImages(): ImageReferenceWithLabel[] {
         return [
-            {
-                label: 'Ubuntu Server 18.04 LTS - Gen1',
-                publisher: 'Canonical',
-                offer: 'UbuntuServer',
-                sku: '18.04-LTS',
-                version: 'latest'
-            },
+            ubuntu1804LTSImage,
             {
                 label: 'Red Hat Enterprise Linux 8.2 (LVM) - Gen1',
                 publisher: 'RedHat',

--- a/src/commands/createVirtualMachine/createVirtualMachine.ts
+++ b/src/commands/createVirtualMachine/createVirtualMachine.ts
@@ -3,14 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext } from "vscode-azureextensionui";
+import { IActionContext, ICreateChildImplContext } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import { SubscriptionTreeItem } from '../../tree/SubscriptionTreeItem';
 
-export async function createVirtualMachine(context: IActionContext, node?: SubscriptionTreeItem | undefined): Promise<void> {
+export async function createVirtualMachine(context: IActionContext & Partial<ICreateChildImplContext>, node?: SubscriptionTreeItem | undefined): Promise<void> {
     if (!node) {
         node = await ext.tree.showTreeItemPicker<SubscriptionTreeItem>(SubscriptionTreeItem.contextValue, context);
     }
 
     await node.createChild(context);
+}
+
+export async function createVirtualMachineAdvanced(context: IActionContext, node?: SubscriptionTreeItem | undefined): Promise<void> {
+    await createVirtualMachine({ ...context, advancedCreation: true }, node);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { AzExtTreeDataProvider, AzureTreeItem, AzureUserInput, callWithTelemetry
 import { AzureExtensionApi, AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { addSshKey } from './commands/addSshKey';
 import { revealTreeItem } from './commands/api/revealTreeItem';
-import { createVirtualMachine } from './commands/createVirtualMachine/createVirtualMachine';
+import { createVirtualMachine, createVirtualMachineAdvanced } from './commands/createVirtualMachine/createVirtualMachine';
 import { deleteNode } from './commands/deleteNode';
 import { openInPortal } from './commands/openInPortal';
 import { startVirtualMachine } from './commands/startVirtualMachine';
@@ -45,6 +45,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         registerCommand('azureVirtualMachines.loadMore', async (actionContext: IActionContext, node: AzureTreeItem) => await ext.tree.loadMore(node, actionContext));
         registerCommand('azureVirtualMachines.openInPortal', openInPortal);
         registerCommand('azureVirtualMachines.createVirtualMachine', createVirtualMachine);
+        registerCommand('azureVirtualMachines.createVirtualMachineAdvanced', createVirtualMachineAdvanced);
         registerCommand('azureVirtualMachines.startVirtualMachine', startVirtualMachine);
         registerCommand('azureVirtualMachines.stopVirtualMachine', stopVirtualMachine);
         registerCommand('azureVirtualMachines.addSshKey', addSshKey);

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -6,7 +6,7 @@
 import { ComputeManagementClient, ComputeManagementModels } from '@azure/arm-compute';
 import { AzExtTreeItem, AzureTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, createAzureClient, ICreateChildImplContext, LocationListStep, parseError, ResourceGroupCreateStep, SubscriptionTreeItemBase } from 'vscode-azureextensionui';
 import { getAvailableVMLocations } from '../commands/createVirtualMachine/getAvailableVMLocations';
-import { ImageListStep } from '../commands/createVirtualMachine/ImageListStep';
+import { ImageListStep, ubuntu1804LTSImage } from '../commands/createVirtualMachine/ImageListStep';
 import { IVirtualMachineWizardContext } from '../commands/createVirtualMachine/IVirtualMachineWizardContext';
 import { NetworkInterfaceCreateStep } from '../commands/createVirtualMachine/NetworkInterfaceCreateStep';
 import { NetworkSecurityGroupCreateStep } from '../commands/createVirtualMachine/NetworkSecurityGroupCreateStep';
@@ -101,8 +101,8 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         const title: string = 'Create new virtual machine';
 
         if (!context.advancedCreation) {
-            // for basic create, default to image Ubuntu 18.04 LTS, the first on the list
-            wizardContext.image = new ImageListStep().getAvailableImages()[0];
+            // for basic create, default to image Ubuntu 18.04 LTS
+            wizardContext.image = ubuntu1804LTSImage;
         }
 
         const wizard: AzureWizard<IVirtualMachineWizardContext> = new AzureWizard(wizardContext, { promptSteps, executeSteps, title });

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -6,6 +6,7 @@
 import { ComputeManagementClient, ComputeManagementModels } from '@azure/arm-compute';
 import { AzExtTreeItem, AzureTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, createAzureClient, ICreateChildImplContext, LocationListStep, parseError, ResourceGroupCreateStep, SubscriptionTreeItemBase } from 'vscode-azureextensionui';
 import { getAvailableVMLocations } from '../commands/createVirtualMachine/getAvailableVMLocations';
+import { ImageListStep } from '../commands/createVirtualMachine/ImageListStep';
 import { IVirtualMachineWizardContext } from '../commands/createVirtualMachine/IVirtualMachineWizardContext';
 import { NetworkInterfaceCreateStep } from '../commands/createVirtualMachine/NetworkInterfaceCreateStep';
 import { NetworkSecurityGroupCreateStep } from '../commands/createVirtualMachine/NetworkSecurityGroupCreateStep';
@@ -86,8 +87,12 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         if (promptForPassphrase) {
             promptSteps.push(new PassphrasePromptStep());
         }
-        LocationListStep.addStep(wizardContext, promptSteps);
 
+        if (context.advancedCreation) {
+            promptSteps.push(new ImageListStep());
+        }
+
+        LocationListStep.addStep(wizardContext, promptSteps);
         executeSteps.push(new ResourceGroupCreateStep());
         executeSteps.push(new PublicIpCreateStep());
         executeSteps.push(new VirtualNetworkCreateStep());

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -87,12 +87,9 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         if (promptForPassphrase) {
             promptSteps.push(new PassphrasePromptStep());
         }
-
-        if (context.advancedCreation) {
-            promptSteps.push(new ImageListStep());
-        }
-
+        promptSteps.push(new ImageListStep());
         LocationListStep.addStep(wizardContext, promptSteps);
+
         executeSteps.push(new ResourceGroupCreateStep());
         executeSteps.push(new PublicIpCreateStep());
         executeSteps.push(new VirtualNetworkCreateStep());
@@ -102,6 +99,12 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         executeSteps.push(new VirtualMachineCreateStep());
 
         const title: string = 'Create new virtual machine';
+
+        if (!context.advancedCreation) {
+            // for basic create, default to image Ubuntu 18.04 LTS, the first on the list
+            wizardContext.image = new ImageListStep().getAvailableImages()[0];
+        }
+
         const wizard: AzureWizard<IVirtualMachineWizardContext> = new AzureWizard(wizardContext, { promptSteps, executeSteps, title });
 
         await wizard.prompt();


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/98
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/107
Partially fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/2

Right now we're still limited to Linux VMs.  I think the next step will to include the Windows images listed in the Portal

![image](https://user-images.githubusercontent.com/5290572/89831049-0fd91280-db12-11ea-962e-71fd48899f12.png)

After that, I'll implement the size.

The images are hard-coded for now.  I was investigating for a while, but I wasn't able to find a way to use the API to get the "recommended" picks from the Portal.  Furthermore, the virtualMachineImages API didn't return a human-readable string for the display name so using the API to retrieve the vmImage seemed somewhat pointless.

I ended up just creating a bunch of VMs from the Portal and looked at what their OS configurations were set to to hardcore these values.  Jing is trying to get me in contact with someone in the VS team that dealt with creating VMs through VS so hopefully I can figure out a more dynamic solution.
