### PR TITLE
Decode os.homedir path

### DIFF
--- a/src/utils/sshUtils.ts
+++ b/src/utils/sshUtils.ts
@@ -12,7 +12,7 @@ import { localize } from '../localize';
 import { VirtualMachineTreeItem } from '../tree/VirtualMachineTreeItem';
 import { cpUtils } from "./cpUtils";
 
-export const sshFsPath: string = join(os.homedir(), '.ssh');
+export const sshFsPath: string = join(decodeURI(os.homedir()), '.ssh');
 
 export async function getSshKey(vmName: string, passphrase: string): Promise<string> {
     return await callWithMaskHandling(


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/127

I'm pretty sure `os.homedir()` is returning the encoded path for some reason (indicated by the %5C).  Nothing in the documentation indicates to me that it should. https://nodejs.org/api/os.html#os_os_homedir  But perhaps the original issue had a custom `USERPROFILE` environment variable defined?