### PR TITLE
🏃‍♀️🔵Conform component naming convention to portal 🟠🏃‍♀️

### DIFF
--- a/src/commands/createVirtualMachine/NetworkInterfaceCreateStep.ts
+++ b/src/commands/createVirtualMachine/NetworkInterfaceCreateStep.ts
@@ -20,7 +20,7 @@ export class NetworkInterfaceCreateStep extends AzureWizardExecuteStep<IVirtualM
         const vmName: string = nonNullProp(context, 'newVirtualMachineName');
 
         // this is the naming convention used by the portal
-        context.newNetworkInterfaceName = context.newNetworkInterfaceName || this.appendThreeRandomDigits(vmName);
+        context.newNetworkInterfaceName = context.newNetworkInterfaceName || this.formatNetworkInterfaceName(vmName);
 
         const publicIpAddress: NetworkManagementModels.PublicIPAddress = nonNullProp(context, 'publicIpAddress');
         const subnet: NetworkManagementModels.Subnet = nonNullProp(context, 'subnet');
@@ -42,7 +42,11 @@ export class NetworkInterfaceCreateStep extends AzureWizardExecuteStep<IVirtualM
         return !context.networkInterface;
     }
 
-    private appendThreeRandomDigits(niName: string): string {
+    private formatNetworkInterfaceName(niName: string): string {
+        const maxNumofChars: number = 20;
+        // the portal truncates the VM name by 20 characters
+        niName = niName.substr(0, maxNumofChars);
+
         for (let i: number = 0; i < 3; i += 1) {
             // as this isn't being used for security purposes, it should be sufficient to use Math.random()
             // tslint:disable-next-line: insecure-random

--- a/src/commands/createVirtualMachine/VirtualNetworkCreateStep.ts
+++ b/src/commands/createVirtualMachine/VirtualNetworkCreateStep.ts
@@ -20,7 +20,7 @@ export class VirtualNetworkCreateStep extends AzureWizardExecuteStep<IVirtualMac
 
         const virtualNetworkProps: NetworkManagementModels.VirtualNetwork = { location, addressSpace: { addressPrefixes: [nonNullProp(context, 'addressPrefix')] } };
         const rgName: string = nonNullValueAndProp(context.resourceGroup, 'name');
-        const vnName: string = nonNullProp(context, 'newVirtualMachineName') + '-vnet';
+        const vnName: string = nonNullProp(context, 'newVirtualMachineName');
 
         const creatingVn: string = localize('creatingVn', `Creating new virtual network "${vnName}"...`);
         ext.outputChannel.appendLog(creatingVn);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/81

Trying to follow naming conventions from here:
![image](https://user-images.githubusercontent.com/5290572/90943206-c61fe000-e3cd-11ea-88b7-de085473d1c0.png)
