### PR TITLE
Check for . and - at beginning

### DIFF
--- a/src/commands/createVirtualMachine/VirtualMachineNameStep.ts
+++ b/src/commands/createVirtualMachine/VirtualMachineNameStep.ts
@@ -46,8 +46,8 @@ export class VirtualMachineNameStep extends AzureNameStep<IVirtualMachineWizardC
             return localize('invalidLength', 'The name must be between {0} and {1} characters.', virtualMachineNamingRules.minLength, virtualMachineNamingRules.maxLength);
         } else if (virtualMachineNamingRules.invalidCharsRegExp.test(name)) {
             return localize('invalidChars', "The name can only contain alphanumeric characters and the symbols '.' and '-'");
-        } else if (name.endsWith('.') || name.endsWith('-')) {
-            return localize('invalidEndingChar', "The name cannot end in a '.' or '-'.");
+        } else if (name.startsWith('.') || name.endsWith('.') || name.startsWith('-') || name.endsWith('-')) {
+            return localize('invalidEndingChar', "The name cannot start or end in a '.' or '-'.");
         } else if (wizardContext.resourceGroup?.name && !await this.isNameAvailableInRG(wizardContext, wizardContext.resourceGroup.name, name)) {
             return localize('nameAlreadyExists', 'Virtual machine name "{0}" already exists in resource group "{1}".', name, wizardContext.resourceGroup.name);
         } else {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/128

Despite what the validation rules say, the portal won't let you start with a "." or "-" either.
![image](https://user-images.githubusercontent.com/5290572/91225889-2027ea80-e6d9-11ea-9d5f-e89f6bae89a0.png)
