### PR TITLE
Add validation for Windows VM names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,9 +35,9 @@
             }
         },
         "@azure/arm-storage": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-15.0.0.tgz",
-            "integrity": "sha512-aIx8IWxj5cmIBV0Mf0O2N70PboUIb3zSJ5w8UonlIZb2t0Y9uPYOut1DR251KBF4aQVP6TF1HEJoAALsxPtOUw==",
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-15.1.0.tgz",
+            "integrity": "sha512-IWomHlT7eEnCSMDHH/z5/XyPHhGAIPmWYgHkIyYB2YQt+Af+hWvE1NIwI79Eeiu+Am4U8BKUsXWmWKqDYh0Srg==",
             "requires": {
                 "@azure/ms-rest-azure-js": "^2.0.1",
                 "@azure/ms-rest-js": "^2.0.4",
@@ -8596,9 +8596,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.34.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.34.0.tgz",
-            "integrity": "sha512-m2JTdVYFNtuS3p25TiFpUzfKG/VMqcOGcwiLzpyadhN3GGB4o25sQG4r2Vw93vRqNj8ZrKsQqD9swU3L2FDkkQ==",
+            "version": "0.35.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.35.0.tgz",
+            "integrity": "sha512-uf86hfwevZysrB1BaqzhKB54W5P4ZYiilrosbwnjnBupI3RV206LF+LxXDzQrwEwhJXWoFaumNuSw5V+xQe3qg==",
             "requires": {
                 "@azure/arm-resources": "^3.0.0",
                 "@azure/arm-storage": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
         "@azure/arm-network": "^22.0.0",
         "fs-extra": "^8.1.0",
         "semver": "^5.7.0",
-        "vscode-azureextensionui": "^0.34.0",
+        "vscode-azureextensionui": "^0.35.0",
         "vscode-nls": "^4.1.0"
     },
     "extensionDependencies": [

--- a/src/commands/createVirtualMachine/ImageListStep.ts
+++ b/src/commands/createVirtualMachine/ImageListStep.ts
@@ -23,13 +23,6 @@ export const ubuntu1804LTSImage: ImageReferenceWithLabel = {
 export class ImageListStep extends AzureWizardPromptStep<IVirtualMachineWizardContext> {
 
     public async prompt(context: IVirtualMachineWizardContext): Promise<void> {
-        if (context.os === VirtualMachineOS.windows && context.newVirtualMachineName?.includes('.')) {
-            const nameWithNoPeriods: string | undefined = context.newVirtualMachineName?.replace(/\./g, '');
-            const noPeriods: string = localize('noPeriods', 'Windows VM names cannot contain periods.  Use "{0}" instead?', nameWithNoPeriods);
-            await ext.ui.showWarningMessage(noPeriods, { modal: true }, { title: localize('use', 'Use') });
-            context.newVirtualMachineName = nameWithNoPeriods;
-        }
-
         const placeHolder: string = localize('selectImage', 'Select an image');
         context.image = (await ext.ui.showQuickPick(this.getAvailableImages(context.os).map((ir) => { return { label: ir.label, data: ir }; }), {
             placeHolder

--- a/src/commands/createVirtualMachine/ImageListStep.ts
+++ b/src/commands/createVirtualMachine/ImageListStep.ts
@@ -23,6 +23,13 @@ export const ubuntu1804LTSImage: ImageReferenceWithLabel = {
 export class ImageListStep extends AzureWizardPromptStep<IVirtualMachineWizardContext> {
 
     public async prompt(context: IVirtualMachineWizardContext): Promise<void> {
+        if (context.os === VirtualMachineOS.windows && context.newVirtualMachineName?.includes('.')) {
+            const nameWithNoPeriods: string | undefined = context.newVirtualMachineName?.replace(/\./g, '');
+            const noPeriods: string = localize('noPeriods', 'Windows VM names cannot contain periods.  Use "{0}" instead?', nameWithNoPeriods);
+            await ext.ui.showWarningMessage(noPeriods, { modal: true }, { title: localize('use', 'Use') });
+            context.newVirtualMachineName = nameWithNoPeriods;
+        }
+
         const placeHolder: string = localize('selectImage', 'Select an image');
         context.image = (await ext.ui.showQuickPick(this.getAvailableImages(context.os).map((ir) => { return { label: ir.label, data: ir }; }), {
             placeHolder

--- a/src/commands/createVirtualMachine/OSListStep.ts
+++ b/src/commands/createVirtualMachine/OSListStep.ts
@@ -3,10 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizardPromptStep, IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { IVirtualMachineWizardContext } from './IVirtualMachineWizardContext';
+import { ValidateWindowsNameStep } from './ValidateWindowsNameStep';
 
 export enum VirtualMachineOS {
     linux = 'linux',
@@ -24,6 +25,14 @@ export class OSListStep extends AzureWizardPromptStep<IVirtualMachineWizardConte
 
     public shouldPrompt(wizardContext: IVirtualMachineWizardContext): boolean {
         return wizardContext.os === undefined;
+    }
+
+    public async getSubWizard(wizardContext: IVirtualMachineWizardContext): Promise<IWizardOptions<IVirtualMachineWizardContext> | undefined> {
+        if (wizardContext.os === VirtualMachineOS.windows) {
+            return { promptSteps: [new ValidateWindowsNameStep()] };
+        }
+
+        return undefined;
     }
 
     private getWebsiteOSDisplayName(kind: VirtualMachineOS): string {

--- a/src/commands/createVirtualMachine/OSListStep.ts
+++ b/src/commands/createVirtualMachine/OSListStep.ts
@@ -19,7 +19,6 @@ export class OSListStep extends AzureWizardPromptStep<IVirtualMachineWizardConte
             const os: VirtualMachineOS = <VirtualMachineOS>VirtualMachineOS[key];
             return { label: this.getWebsiteOSDisplayName(os), data: os };
         });
-
         wizardContext.os = (await ext.ui.showQuickPick(picks, { placeHolder: localize('selectOS', 'Select an OS.') })).data;
     }
 

--- a/src/commands/createVirtualMachine/ValidateWindowsNameStep.ts
+++ b/src/commands/createVirtualMachine/ValidateWindowsNameStep.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardPromptStep } from 'vscode-azureextensionui';
+import { ext } from '../../extensionVariables';
+import { localize } from '../../localize';
+import { IVirtualMachineWizardContext } from './IVirtualMachineWizardContext';
+
+export class ValidateWindowsNameStep extends AzureWizardPromptStep<IVirtualMachineWizardContext> {
+    public async prompt(wizardContext: IVirtualMachineWizardContext): Promise<void> {
+        const nameWithNoPeriods: string | undefined = wizardContext.newVirtualMachineName?.replace(/\./g, '');
+        const noPeriods: string = localize('noPeriods', 'Windows VM names cannot contain periods.  Use "{0}" instead?', nameWithNoPeriods);
+        await ext.ui.showWarningMessage(noPeriods, { modal: true }, { title: localize('use', 'Use') });
+        wizardContext.newVirtualMachineName = nameWithNoPeriods;
+    }
+
+    public shouldPrompt(wizardContext: IVirtualMachineWizardContext): boolean {
+        return wizardContext.newVirtualMachineName?.includes('.') || false;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/149

Windows VM's don't actually allow "." in their names.  Since we can't know the OS prior to the name step, we'll have to check & remove them after selecting the OS type.