### PR TITLE
Change naming for vnet so they wont be 1 char

### DIFF
--- a/src/commands/createVirtualMachine/VirtualNetworkCreateStep.ts
+++ b/src/commands/createVirtualMachine/VirtualNetworkCreateStep.ts
@@ -20,7 +20,9 @@ export class VirtualNetworkCreateStep extends AzureWizardExecuteStep<IVirtualMac
 
         const virtualNetworkProps: NetworkManagementModels.VirtualNetwork = { location, addressSpace: { addressPrefixes: [nonNullProp(context, 'addressPrefix')] } };
         const rgName: string = nonNullValueAndProp(context.resourceGroup, 'name');
-        const vnName: string = nonNullProp(context, 'newVirtualMachineName');
+        const vmName: string = nonNullProp(context, 'newVirtualMachineName');
+        // network names can't be 1 character and will fail the creation
+        const vnName: string = vmName.length === 1 ? `${vmName}-vnet` : vmName;
 
         const creatingVn: string = localize('creatingVn', `Creating new virtual network "${vnName}"...`);
         ext.outputChannel.appendLog(creatingVn);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/153

The portal name validation doesn't check this, but virtual networks can't be 1 letter long.  I tried with 2 characters, and that seems to work fine.

Virtual machines _can_ be 1 letter long, so we should have the validation at the network level, not the vm itself.