### PR TITLE
Some telemetry about VMs being created

### DIFF
--- a/src/commands/createVirtualMachine/IVirtualMachineWizardContext.ts
+++ b/src/commands/createVirtualMachine/IVirtualMachineWizardContext.ts
@@ -6,6 +6,7 @@
 import { ComputeManagementModels } from '@azure/arm-compute';
 import { NetworkManagementModels } from '@azure/arm-network';
 import { IResourceGroupWizardContext } from 'vscode-azureextensionui';
+import { ImageReferenceWithLabel } from './ImageListStep';
 import { VirtualMachineOS } from './OSListStep';
 
 export interface IVirtualMachineWizardContext extends IResourceGroupWizardContext {
@@ -34,7 +35,7 @@ export interface IVirtualMachineWizardContext extends IResourceGroupWizardContex
     /**
      * The image used to create the VM.  The default is `Ubuntu Server 18.04 LTS`.
      */
-    image?: ComputeManagementModels.ImageReference;
+    image?: ImageReferenceWithLabel;
 
     /**
      * The network interface of the new VM.  This contains all the ipConfigurations such as public IP and subnet

--- a/src/commands/createVirtualMachine/ImageListStep.ts
+++ b/src/commands/createVirtualMachine/ImageListStep.ts
@@ -10,7 +10,7 @@ import { localize } from '../../localize';
 import { IVirtualMachineWizardContext } from './IVirtualMachineWizardContext';
 import { VirtualMachineOS } from './OSListStep';
 
-type ImageReferenceWithLabel = ComputeManagementModels.ImageReference & { label: string };
+export type ImageReferenceWithLabel = ComputeManagementModels.ImageReference & { label: string };
 
 export const ubuntu1804LTSImage: ImageReferenceWithLabel = {
     label: 'Ubuntu Server 18.04 LTS - Gen1',

--- a/src/commands/createVirtualMachine/VirtualMachineCreateStep.ts
+++ b/src/commands/createVirtualMachine/VirtualMachineCreateStep.ts
@@ -18,6 +18,11 @@ export class VirtualMachineCreateStep extends AzureWizardExecuteStep<IVirtualMac
     public priority: number = 260;
 
     public async execute(context: IVirtualMachineWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
+        context.telemetry.properties.os = context.os;
+        context.telemetry.properties.image = context.image?.label;
+        context.telemetry.properties.location = context.location?.name;
+        context.telemetry.properties.size = context.size;
+
         const computeClient: ComputeManagementClient = createAzureClient(context, ComputeManagementClient);
         const hardwareProfile: ComputeManagementModels.HardwareProfile = { vmSize: context.size };
 
@@ -69,11 +74,6 @@ export class VirtualMachineCreateStep extends AzureWizardExecuteStep<IVirtualMac
         progress.report({ message: creatingVm });
         context.virtualMachine = await computeClient.virtualMachines.createOrUpdate(rgName, vmName, virtualMachineProps);
         ext.outputChannel.appendLog(createdVm);
-
-        context.telemetry.properties.os = context.os;
-        context.telemetry.properties.image = context.image?.label;
-        context.telemetry.properties.location = context.location?.name;
-        context.telemetry.properties.size = context.size;
 
         const viewOutput: MessageItem = { title: 'View Output' };
         // Note: intentionally not waiting for the result of this before returning

--- a/src/commands/createVirtualMachine/VirtualMachineCreateStep.ts
+++ b/src/commands/createVirtualMachine/VirtualMachineCreateStep.ts
@@ -70,6 +70,11 @@ export class VirtualMachineCreateStep extends AzureWizardExecuteStep<IVirtualMac
         context.virtualMachine = await computeClient.virtualMachines.createOrUpdate(rgName, vmName, virtualMachineProps);
         ext.outputChannel.appendLog(createdVm);
 
+        context.telemetry.properties.os = context.os;
+        context.telemetry.properties.image = context.image?.label;
+        context.telemetry.properties.location = context.location?.name;
+        context.telemetry.properties.size = context.size;
+
         const viewOutput: MessageItem = { title: 'View Output' };
         // Note: intentionally not waiting for the result of this before returning
         window.showInformationMessage(createdVm, viewOutput).then(async (result: MessageItem | undefined) => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/144

Let me know if anyone thinks of anything else useful.

Changed the context's ImageReference type because the display label name is more useful than anything on just ImageReference.