### PR TITLE
Fallback to Azure SSH keys if keygen fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -382,7 +382,8 @@
         "@types/which": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
-            "integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA=="
+            "integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==",
+            "dev": true
         },
         "@webassemblyjs/ast": {
             "version": "1.7.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@azure/arm-compute": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-compute/-/arm-compute-14.0.0.tgz",
-            "integrity": "sha512-gxh8S2JDJzwiOpKDKyLBAZ+dyzqoVxEAsJVUsPEX09nWUwXt2q5HScIACTCjRB7s22z+MJQVOaCbvXbhbxj25g==",
+            "version": "15.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-compute/-/arm-compute-15.0.0.tgz",
+            "integrity": "sha512-ElV2MuYZ+B2+ygMx2iiM/u3C7WDRruZjkXzfk5p2O+UbWxjG6j/686OH3T+VSDqmzg+47AnIOTLu2v0u0H8FOw==",
             "requires": {
                 "@azure/ms-rest-azure-js": "^2.0.1",
                 "@azure/ms-rest-js": "^2.0.4",
@@ -15,9 +15,9 @@
             }
         },
         "@azure/arm-network": {
-            "version": "22.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-network/-/arm-network-22.0.0.tgz",
-            "integrity": "sha512-qeCblrZYRfSrWLbqkP5C/xiYP8paR6hKKQd8+tuLPQh4B7lthq+tRUfhuUFDDap29KtpX36WqCt3sCqxXHnWUA==",
+            "version": "23.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-network/-/arm-network-23.0.0.tgz",
+            "integrity": "sha512-T33TyIg3rGfRsZfmlIwfu/BJdtf/F0gojR5q+deAWEUMtBqiNOnFFm8H0JiecR4753Ea4HATaqW8IFEjXAoKlQ==",
             "requires": {
                 "@azure/ms-rest-azure-js": "^2.0.1",
                 "@azure/ms-rest-js": "^2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -379,6 +379,11 @@
                 }
             }
         },
+        "@types/which": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
+            "integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA=="
+        },
         "@webassemblyjs/ast": {
             "version": "1.7.11",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
@@ -2185,6 +2190,17 @@
                 "semver": "^5.5.0",
                 "shebang-command": "^1.2.0",
                 "which": "^1.2.9"
+            },
+            "dependencies": {
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
             }
         },
         "crypt": {
@@ -4191,6 +4207,17 @@
                 "ini": "^1.3.4",
                 "is-windows": "^1.0.1",
                 "which": "^1.2.14"
+            },
+            "dependencies": {
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
             }
         },
         "globby": {
@@ -4850,8 +4877,7 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
             "version": "3.0.1",
@@ -5753,6 +5779,15 @@
                     "dev": true,
                     "requires": {
                         "is-number": "^7.0.0"
+                    }
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
                     }
                 },
                 "which-module": {
@@ -9099,6 +9134,17 @@
                         "ini": "^1.3.5",
                         "kind-of": "^6.0.2",
                         "which": "^1.3.1"
+                    },
+                    "dependencies": {
+                        "which": {
+                            "version": "1.3.1",
+                            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                            "dev": true,
+                            "requires": {
+                                "isexe": "^2.0.0"
+                            }
+                        }
                     }
                 },
                 "invert-kv": {
@@ -9292,10 +9338,9 @@
             }
         },
         "which": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-            "dev": true,
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "requires": {
                 "isexe": "^2.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -296,6 +296,7 @@
         "@types/node": "^12.0.0",
         "@types/request": "2.0.7",
         "@types/vscode": "1.47.0",
+        "@types/which": "^1.3.2",
         "glob": "^7.1.6",
         "gulp": "^4.0.2",
         "mocha": "^7.1.1",
@@ -317,7 +318,8 @@
         "fs-extra": "^8.1.0",
         "semver": "^5.7.0",
         "vscode-azureextensionui": "^0.37.0",
-        "vscode-nls": "^4.1.0"
+        "vscode-nls": "^4.1.0",
+        "which": "^2.0.2"
     },
     "extensionDependencies": [
         "ms-vscode.azure-account"

--- a/package.json
+++ b/package.json
@@ -312,8 +312,8 @@
         "webpack-cli": "^3.3.0"
     },
     "dependencies": {
-        "@azure/arm-compute": "^14.0.0",
-        "@azure/arm-network": "^22.0.0",
+        "@azure/arm-compute": "^15.0.0",
+        "@azure/arm-network": "^23.0.0",
         "fs-extra": "^8.1.0",
         "semver": "^5.7.0",
         "vscode-azureextensionui": "^0.37.0",

--- a/src/commands/createVirtualMachine/VirtualMachineCreateStep.ts
+++ b/src/commands/createVirtualMachine/VirtualMachineCreateStep.ts
@@ -38,7 +38,8 @@ export class VirtualMachineCreateStep extends AzureWizardExecuteStep<IVirtualMac
 
         const windowConfiguration: ComputeManagementModels.WindowsConfiguration = {};
         const linuxConfiguration: ComputeManagementModels.LinuxConfiguration = {
-            disablePasswordAuthentication: true, ssh: {
+            disablePasswordAuthentication: true,
+            ssh: {
                 publicKeys: [{
                     // tslint:disable-next-line: strict-boolean-expressions
                     keyData: await getSshKey(context, vmName, context.passphrase || ''),

--- a/src/commands/createVirtualMachine/VirtualMachineCreateStep.ts
+++ b/src/commands/createVirtualMachine/VirtualMachineCreateStep.ts
@@ -41,7 +41,7 @@ export class VirtualMachineCreateStep extends AzureWizardExecuteStep<IVirtualMac
             disablePasswordAuthentication: true, ssh: {
                 publicKeys: [{
                     // tslint:disable-next-line: strict-boolean-expressions
-                    keyData: await getSshKey(vmName, context.passphrase || ''),
+                    keyData: await getSshKey(context, vmName, context.passphrase || ''),
                     // because this is a Linux VM, use '/' as path separator rather than using path.join()
                     path: `/home/${context.adminUsername}/.ssh/authorized_keys`
                 }]

--- a/src/commands/openInPortal.ts
+++ b/src/commands/openInPortal.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureTreeItem, IActionContext } from 'vscode-azureextensionui';
+import which = require('which');
 import { ext } from '../extensionVariables';
 import { VirtualMachineTreeItem } from '../tree/VirtualMachineTreeItem';
 

--- a/src/commands/openInPortal.ts
+++ b/src/commands/openInPortal.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureTreeItem, IActionContext } from 'vscode-azureextensionui';
-import which = require('which');
 import { ext } from '../extensionVariables';
 import { VirtualMachineTreeItem } from '../tree/VirtualMachineTreeItem';
 

--- a/src/utils/sshUtils.ts
+++ b/src/utils/sshUtils.ts
@@ -7,7 +7,8 @@ import { ComputeManagementClient, ComputeManagementModels } from '@azure/arm-com
 import * as fse from 'fs-extra';
 import * as os from "os";
 import { join } from 'path';
-import { callWithMaskHandling, parseError } from 'vscode-azureextensionui';
+import { callWithMaskHandling } from 'vscode-azureextensionui';
+import * as which from 'which';
 import { IVirtualMachineWizardContext } from '../commands/createVirtualMachine/IVirtualMachineWizardContext';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
@@ -92,12 +93,11 @@ export async function configureSshConfig(vmti: VirtualMachineTreeItem, sshKeyPat
 
 async function sshKeygenExists(): Promise<boolean> {
     try {
-        // this command should _always_ fail.  If ssh-keygen exists, it will throw an unknown option error.  If it doesn't, then it'll throw the not recognized error.
-        // unfortunately both return error code 1 so we have to rely on the English text
-        await cpUtils.executeCommand(undefined, undefined, 'ssh-keygen', '--fake');
+        // throws an error if it can't find cmd in PATH env
+        await which('ssh-keygen');
     } catch (err) {
-        return !parseError(err).message.includes(`'ssh-keygen' is not recognized as an internal or external command`);
+        return false;
     }
 
-    return false;
+    return true;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/95
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/142

This doesn't actually fix 142 exactly, but adding SSH key as a wizard step felt pointless especially since Azure keys don't support passphrases.  Also, since it's an internet transaction, there's potentially more security risks (than generating it all locally).