### PR TITLE
Use ssh-config package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7496,6 +7496,11 @@
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
+        "ssh-config": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/ssh-config/-/ssh-config-4.0.4.tgz",
+            "integrity": "sha512-dlEgIpvikPUT1P8GseEStlvQ09SUj7QvldEdWrmpWYrzYdQzVMmRx3tXFdFWTyiTo/4FHVniFo7CvQL5XIf7YQ=="
+        },
         "sshpk": {
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",

--- a/package.json
+++ b/package.json
@@ -316,6 +316,7 @@
         "@azure/arm-network": "^22.0.0",
         "fs-extra": "^8.1.0",
         "semver": "^5.7.0",
+        "ssh-config": "^4.0.4",
         "vscode-azureextensionui": "^0.37.0",
         "vscode-nls": "^4.1.0"
     },

--- a/src/ssh-config.d.ts
+++ b/src/ssh-config.d.ts
@@ -1,0 +1,69 @@
+// Copied from https://github.com/microsoft/vscode-remote-ssh/blob/186fbac18b4859ab70f2c7332b5f608a49e45dc7/open-ssh-remote/src/typings/ssh-config.d.ts
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'ssh-config' {
+
+    export type LeafConfigurationEntry = ConfigurationDirective | ConfigurationComment;
+    export type ConfigurationEntry = HostConfigurationDirective | LeafConfigurationEntry;
+
+    export const enum Type {
+        Directive = 1,
+        Comment = 2
+    }
+
+    export interface Configuration extends Array<ConfigurationEntry> {
+        compute(host: string): ResolvedConfiguration;
+
+        /**
+         * Appends a map of parameters to values. If "Host" is included
+         * as one of the keys, all subsequent keys will be nested under
+         * that host entry.
+         */
+        append(options: { [key: string]: string }): void;
+
+        /**
+         * Prints the properly formatted configuration.
+         */
+        toString(): string;
+    }
+
+    /**
+     * Should match CASE_NORMALIZED_PROPS to be normalized to this casing
+     */
+    export interface ResolvedConfiguration {
+        Host: string;
+        HostName: string;
+        IdentityFile: string[];
+        User: string;
+        Port: string;
+        ConnectTimeout?: string;
+        RemoteCommand?: string;
+        LocalForward?: string[];
+    }
+
+    export interface BaseConfigurationDirective {
+        type: Type.Directive;
+        param: string;
+        value: string | string[];
+    }
+
+    export interface ConfigurationDirective extends BaseConfigurationDirective {
+        value: string;
+    }
+
+    export interface HostConfigurationDirective extends BaseConfigurationDirective {
+        param: 'Host';
+        config: LeafConfigurationEntry[];
+    }
+
+    export interface ConfigurationComment {
+        type: Type.Comment;
+        content: string;
+    }
+
+    export function parse(raw: string): Configuration;
+
+    export function stringify(directive: ReadonlyArray<HostConfigurationDirective>): string;
+}

--- a/src/utils/sshUtils.ts
+++ b/src/utils/sshUtils.ts
@@ -61,7 +61,7 @@ export async function configureSshConfig(vmti: VirtualMachineTreeItem, sshKeyPat
         let count: number = 2;
 
         // increment until host doesn't already exist
-        while (!!sshConfig.compute(`${vmti.name}-${count}`).Host) {
+        while (!!sshConfig.compute(`${vmti.name}-${count}`).Host && count < 100) {
             count = count + 1;
         }
 


### PR DESCRIPTION
I'm leveraging this package to do ssh config manipulations: https://www.npmjs.com/package/ssh-config

Unfortunately, there aren't any typings for it, but it's pretty straight forward on how to use.

There was a bug on how I used to look for existing hosts.  Specifically includes would wrongfully say a host existed.  For example, if your VM name was "test_vm" and your config file had a host "test_vm-2", includes would say that "test_vm" already existed (since include doesn't look for exact matches).  But if we don't parse the config file into a JSON, then it's just one giant string and it's cumbersome to look for exact matches.

Anyway, this fixes that.