### PR TITLE
Nat/linux context

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,15 @@ If you have an existing VM that you would like to add your own SSH key too, you 
 
 Your SSH Config (`~/.ssh/config`) file will be updated so you can connect via SSH using `$ ssh vm-name`.
 
+> NOTE: This command is only available for Linux virtual machines.
+
 ![AddSSHKey](resources/readme/AddSSHKey.png)
 
 ### Remote into Azure VM via SSH
 
 - Use [Visual Studio Code Remote - SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) to seamlessly connect to your Azure VM from VS Code.
+
+> NOTE: This command is only available for Linux virtual machines.
 
 <!-- region exclude-from-marketplace -->
 

--- a/package.json
+++ b/package.json
@@ -188,42 +188,42 @@
                 },
                 {
                     "command": "azureVirtualMachines.copyIpAddress",
-                    "when": "view == azVmTree && viewItem == azVmVirtualMachine",
+                    "when": "view == azVmTree && viewItem =~ /VirtualMachine$/",
                     "group": "1@1"
                 },
                 {
                     "command": "azureVirtualMachines.viewProperties",
-                    "when": "view == azVmTree && viewItem == azVmVirtualMachine",
+                    "when": "view == azVmTree && viewItem =~ /VirtualMachine$/",
                     "group": "3@1"
                 },
                 {
                     "command": "azureVirtualMachines.openInPortal",
-                    "when": "view == azVmTree && viewItem == azVmVirtualMachine",
+                    "when": "view == azVmTree && viewItem =~ /VirtualMachine$/",
                     "group": "3@2"
                 },
                 {
                     "command": "azureVirtualMachines.startVirtualMachine",
-                    "when": "view == azVmTree && viewItem == azVmVirtualMachine",
+                    "when": "view == azVmTree && viewItem =~ /VirtualMachine$/",
                     "group": "2@1"
                 },
                 {
                     "command": "azureVirtualMachines.restartVirtualMachine",
-                    "when": "view == azVmTree && viewItem == azVmVirtualMachine",
+                    "when": "view == azVmTree && viewItem =~ /VirtualMachine$/",
                     "group": "2@2"
                 },
                 {
                     "command": "azureVirtualMachines.stopVirtualMachine",
-                    "when": "view == azVmTree && viewItem == azVmVirtualMachine",
+                    "when": "view == azVmTree && viewItem =~ /VirtualMachine$/",
                     "group": "2@3"
                 },
                 {
                     "command": "azureVirtualMachines.deleteVirtualMachine",
-                    "when": "view == azVmTree && viewItem == azVmVirtualMachine",
+                    "when": "view == azVmTree && viewItem =~ /VirtualMachine$/",
                     "group": "2@4"
                 },
                 {
                     "command": "azureVirtualMachines.addSshKey",
-                    "when": "view == azVmTree && viewItem == azVmVirtualMachine",
+                    "when": "view == azVmTree && viewItem == linuxVirtualMachine",
                     "group": "1@2"
                 }
             ],

--- a/src/commands/addSshKey.ts
+++ b/src/commands/addSshKey.ts
@@ -16,15 +16,11 @@ import { configureSshConfig, sshFsPath } from "../utils/sshUtils";
 
 export async function addSshKey(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.linuxContextValue, context);
     }
 
     const computeClient: ComputeManagementClient = await createComputeClient(node.root);
     const vm: ComputeManagementModels.VirtualMachine = node.virtualMachine;
-
-    if (!node.isLinux) {
-        throw new Error(localize('notSupportedWindows', 'This operation is not supported on Windows VMs.'));
-    }
 
     const sshPublicKey: Uri = (await ext.ui.showOpenDialog({
         defaultUri: Uri.file(sshFsPath),

--- a/src/commands/copyIpAddress.ts
+++ b/src/commands/copyIpAddress.ts
@@ -11,7 +11,7 @@ import { VirtualMachineTreeItem } from '../tree/VirtualMachineTreeItem';
 
 export async function copyIpAddress(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.regexpContextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.allOSContextValue, context);
     }
 
     await vscode.env.clipboard.writeText(await node.getIpAddress());

--- a/src/commands/copyIpAddress.ts
+++ b/src/commands/copyIpAddress.ts
@@ -11,7 +11,7 @@ import { VirtualMachineTreeItem } from '../tree/VirtualMachineTreeItem';
 
 export async function copyIpAddress(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.regexpContextValue, context);
     }
 
     await vscode.env.clipboard.writeText(await node.getIpAddress());

--- a/src/commands/openInPortal.ts
+++ b/src/commands/openInPortal.ts
@@ -9,7 +9,7 @@ import { VirtualMachineTreeItem } from '../tree/VirtualMachineTreeItem';
 
 export async function openInPortal(context: IActionContext, node?: AzureTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<AzureTreeItem>(VirtualMachineTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<AzureTreeItem>(VirtualMachineTreeItem.regexpContextValue, context);
     }
 
     await node.openInPortal();

--- a/src/commands/openInPortal.ts
+++ b/src/commands/openInPortal.ts
@@ -9,7 +9,7 @@ import { VirtualMachineTreeItem } from '../tree/VirtualMachineTreeItem';
 
 export async function openInPortal(context: IActionContext, node?: AzureTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<AzureTreeItem>(VirtualMachineTreeItem.regexpContextValue, context);
+        node = await ext.tree.showTreeItemPicker<AzureTreeItem>(VirtualMachineTreeItem.allOSContextValue, context);
     }
 
     await node.openInPortal();

--- a/src/commands/restartVirtualMachine.ts
+++ b/src/commands/restartVirtualMachine.ts
@@ -13,7 +13,7 @@ import { nonNullValue } from "../utils/nonNull";
 
 export async function restartVirtualMachine(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.regexpContextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.allOSContextValue, context);
     }
 
     const computeClient: ComputeManagementClient = await createComputeClient(node.root);

--- a/src/commands/restartVirtualMachine.ts
+++ b/src/commands/restartVirtualMachine.ts
@@ -13,7 +13,7 @@ import { nonNullValue } from "../utils/nonNull";
 
 export async function restartVirtualMachine(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.regexpContextValue, context);
     }
 
     const computeClient: ComputeManagementClient = await createComputeClient(node.root);

--- a/src/commands/startVirtualMachine.ts
+++ b/src/commands/startVirtualMachine.ts
@@ -13,7 +13,7 @@ import { nonNullValue } from "../utils/nonNull";
 
 export async function startVirtualMachine(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.regexpContextValue, context);
     }
 
     const computeClient: ComputeManagementClient = await createComputeClient(node.root);

--- a/src/commands/startVirtualMachine.ts
+++ b/src/commands/startVirtualMachine.ts
@@ -13,7 +13,7 @@ import { nonNullValue } from "../utils/nonNull";
 
 export async function startVirtualMachine(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.regexpContextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.allOSContextValue, context);
     }
 
     const computeClient: ComputeManagementClient = await createComputeClient(node.root);

--- a/src/commands/stopVirtualMachine.ts
+++ b/src/commands/stopVirtualMachine.ts
@@ -13,7 +13,7 @@ import { nonNullValue } from "../utils/nonNull";
 
 export async function stopVirtualMachine(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.regexpContextValue, context);
     }
 
     const computeClient: ComputeManagementClient = await createComputeClient(node.root);

--- a/src/commands/stopVirtualMachine.ts
+++ b/src/commands/stopVirtualMachine.ts
@@ -13,7 +13,7 @@ import { nonNullValue } from "../utils/nonNull";
 
 export async function stopVirtualMachine(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.regexpContextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.allOSContextValue, context);
     }
 
     const computeClient: ComputeManagementClient = await createComputeClient(node.root);

--- a/src/commands/viewProperties.ts
+++ b/src/commands/viewProperties.ts
@@ -9,7 +9,7 @@ import { VirtualMachineTreeItem } from '../tree/VirtualMachineTreeItem';
 
 export async function viewProperties(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.regexpContextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.allOSContextValue, context);
     }
 
     await openReadOnlyJson(node, node.data);

--- a/src/commands/viewProperties.ts
+++ b/src/commands/viewProperties.ts
@@ -9,7 +9,7 @@ import { VirtualMachineTreeItem } from '../tree/VirtualMachineTreeItem';
 
 export async function viewProperties(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.contextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.regexpContextValue, context);
     }
 
     await openReadOnlyJson(node, node.data);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         registerCommand('azureVirtualMachines.restartVirtualMachine', restartVirtualMachine);
         registerCommand('azureVirtualMachines.stopVirtualMachine', stopVirtualMachine);
         registerCommand('azureVirtualMachines.addSshKey', addSshKey);
-        registerCommand('azureVirtualMachines.deleteVirtualMachine', async (actionContext: IActionContext, node?: SubscriptionTreeItem) => await deleteNode(actionContext, VirtualMachineTreeItem.contextValue, node));
+        registerCommand('azureVirtualMachines.deleteVirtualMachine', async (actionContext: IActionContext, node?: SubscriptionTreeItem) => await deleteNode(actionContext, VirtualMachineTreeItem.regexpContextValue, node));
         registerCommand('azureVirtualMachines.copyIpAddress', copyIpAddress);
         registerCommand('azureVirtualMachines.viewProperties', viewProperties);
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         registerCommand('azureVirtualMachines.restartVirtualMachine', restartVirtualMachine);
         registerCommand('azureVirtualMachines.stopVirtualMachine', stopVirtualMachine);
         registerCommand('azureVirtualMachines.addSshKey', addSshKey);
-        registerCommand('azureVirtualMachines.deleteVirtualMachine', async (actionContext: IActionContext, node?: SubscriptionTreeItem) => await deleteNode(actionContext, VirtualMachineTreeItem.regexpContextValue, node));
+        registerCommand('azureVirtualMachines.deleteVirtualMachine', async (actionContext: IActionContext, node?: SubscriptionTreeItem) => await deleteNode(actionContext, VirtualMachineTreeItem.allOSContextValue, node));
         registerCommand('azureVirtualMachines.copyIpAddress', copyIpAddress);
         registerCommand('azureVirtualMachines.viewProperties', viewProperties);
     });

--- a/src/tree/VirtualMachineTreeItem.ts
+++ b/src/tree/VirtualMachineTreeItem.ts
@@ -47,6 +47,8 @@ export class VirtualMachineTreeItem extends AzureTreeItem {
 
     public static linuxContextValue: string = 'linuxVirtualMachine';
     public static windowsContextValue: string = 'windowsVirtualMachine';
+    public static regexpContextValue: RegExp = /VirtualMachine$/;
+
     public contextValue: string;
     public virtualMachine: ComputeManagementModels.VirtualMachine;
     public isLinux: boolean;

--- a/src/tree/VirtualMachineTreeItem.ts
+++ b/src/tree/VirtualMachineTreeItem.ts
@@ -45,8 +45,9 @@ export class VirtualMachineTreeItem extends AzureTreeItem {
         return this.virtualMachine;
     }
 
-    public static contextValue: string = 'azVmVirtualMachine';
-    public readonly contextValue: string = VirtualMachineTreeItem.contextValue;
+    public static linuxContextValue: string = 'linuxVirtualMachine';
+    public static windowsContextValue: string = 'windowsVirtualMachine';
+    public contextValue: string;
     public virtualMachine: ComputeManagementModels.VirtualMachine;
     public isLinux: boolean;
     private _state?: string;
@@ -55,7 +56,7 @@ export class VirtualMachineTreeItem extends AzureTreeItem {
         super(parent);
         this.virtualMachine = vm;
         this._state = instanceView ? this.getStateFromInstanceView(instanceView) : undefined;
-        this.isLinux = !!(vm.osProfile?.linuxConfiguration);
+        this.contextValue = !!(vm.osProfile?.linuxConfiguration) ? VirtualMachineTreeItem.linuxContextValue : VirtualMachineTreeItem.windowsContextValue;
     }
 
     public getUser(): string {

--- a/src/tree/VirtualMachineTreeItem.ts
+++ b/src/tree/VirtualMachineTreeItem.ts
@@ -47,7 +47,7 @@ export class VirtualMachineTreeItem extends AzureTreeItem {
 
     public static linuxContextValue: string = 'linuxVirtualMachine';
     public static windowsContextValue: string = 'windowsVirtualMachine';
-    public static regexpContextValue: RegExp = /VirtualMachine$/;
+    public static allOSContextValue: RegExp = /VirtualMachine$/;
 
     public contextValue: string;
     public virtualMachine: ComputeManagementModels.VirtualMachine;


### PR DESCRIPTION
I looked at other UIs besides the Azure portal, but none of them distinguish Linux vs. Windows VMs either through a label/icon.  I see the "This operation is not supported on Windows VMs." pretty frequently in telemetry and I'm adding another Linux only command, so it felt appropriate to just filter the commands out.

I wish there was a better way to distinguish between Windows and Linux VMs, but the user can view properties and see what the OS image is fairly easily.