### PR TITLE
Always create a new SSH key when creating VMs

### DIFF
--- a/src/commands/createVirtualMachine/IVirtualMachineWizardContext.ts
+++ b/src/commands/createVirtualMachine/IVirtualMachineWizardContext.ts
@@ -91,4 +91,9 @@ export interface IVirtualMachineWizardContext extends IResourceGroupWizardContex
      * This will be defined after PassphrasePromptStep.
      */
     passphrase?: string;
+
+    /**
+     * Name of the SSH key used for the new virtual machine
+     */
+    sshKeyName?: string;
 }

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -122,7 +122,9 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         const virtualMachine: ComputeManagementModels.VirtualMachine = nonNullProp(wizardContext, 'virtualMachine');
 
         const newVm: VirtualMachineTreeItem = new VirtualMachineTreeItem(this, virtualMachine, undefined /* assume all newly created VMs are running */);
-        await configureSshConfig(newVm);
+        if (newVm.isLinux) {
+            await configureSshConfig(newVm, `~/.ssh/${wizardContext.sshKeyName}`);
+        }
 
         return newVm;
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/83

I think whenever we're creating a new VM for the user, we should _always_ create a new SSH key pair.  I think that for a first experience, it would suck if the user created a vm, deleted it, and created another one with the same name because it would reuse the SSH key.  Potentially, they could have changed the passphrase and that wouldn't be honored (since it would default to using the old SSH key).

I was thinking we could just overwrite the key if we found that it exist.  Since we're generating it, I don't worry too much about it though it would be bad if they ended up using that key for something else, and then we just deleted it.  Creating extra SSH keys seems like the least risky (even if it'll cause some clutter) option.