### PR TITLE
Add a running/stopped context

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
                 },
                 {
                     "command": "azureVirtualMachines.restartVirtualMachine",
-                    "when": "view == azVmTree && viewItem =~ /^VirtualMachine/",
+                    "when": "view == azVmTree && viewItem =~ /^VirtualMachine.+running/",
                     "group": "2@2"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -193,47 +193,47 @@
                 },
                 {
                     "command": "azureVirtualMachines.copyIpAddress",
-                    "when": "view == azVmTree && viewItem =~ /VirtualMachine$/",
+                    "when": "view == azVmTree && viewItem =~ /^VirtualMachine/",
                     "group": "1@2"
                 },
                 {
                     "command": "azureVirtualMachines.viewProperties",
-                    "when": "view == azVmTree && viewItem =~ /VirtualMachine$/",
+                    "when": "view == azVmTree && viewItem =~ /^VirtualMachine/",
                     "group": "3@1"
                 },
                 {
                     "command": "azureVirtualMachines.openInPortal",
-                    "when": "view == azVmTree && viewItem =~ /VirtualMachine$/",
+                    "when": "view == azVmTree && viewItem =~ /^VirtualMachine/",
                     "group": "3@2"
                 },
                 {
                     "command": "azureVirtualMachines.startVirtualMachine",
-                    "when": "view == azVmTree && viewItem =~ /VirtualMachine$/",
+                    "when": "view == azVmTree && viewItem =~ /^VirtualMachine.+stopped/",
                     "group": "2@1"
                 },
                 {
                     "command": "azureVirtualMachines.restartVirtualMachine",
-                    "when": "view == azVmTree && viewItem =~ /VirtualMachine$/",
+                    "when": "view == azVmTree && viewItem =~ /^VirtualMachine/",
                     "group": "2@2"
                 },
                 {
                     "command": "azureVirtualMachines.stopVirtualMachine",
-                    "when": "view == azVmTree && viewItem =~ /VirtualMachine$/",
+                    "when": "view == azVmTree && viewItem =~ /^VirtualMachine.+running/",
                     "group": "2@3"
                 },
                 {
                     "command": "azureVirtualMachines.deleteVirtualMachine",
-                    "when": "view == azVmTree && viewItem =~ /VirtualMachine$/",
+                    "when": "view == azVmTree && viewItem =~ /^VirtualMachine/",
                     "group": "2@4"
                 },
                 {
                     "command": "azureVirtualMachines.openInRemoteSsh",
-                    "when": "view == azVmTree && viewItem == linuxVirtualMachine",
+                    "when": "view == azVmTree && viewItem =~ /^VirtualMachine.+linux.+running/",
                     "group": "1@1"
                 },
                 {
                     "command": "azureVirtualMachines.addSshKey",
-                    "when": "view == azVmTree && viewItem == linuxVirtualMachine",
+                    "when": "view == azVmTree && viewItem =~ /^VirtualMachine.+linux.+running/",
                     "group": "1@3"
                 }
             ],

--- a/src/commands/addSshKey.ts
+++ b/src/commands/addSshKey.ts
@@ -16,7 +16,7 @@ import { configureSshConfig, sshFsPath } from "../utils/sshUtils";
 
 export async function addSshKey(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.linuxContextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(/^VirtualMachine.+linux.+running/, context);
     }
 
     const computeClient: ComputeManagementClient = await createComputeClient(node.root);

--- a/src/commands/copyIpAddress.ts
+++ b/src/commands/copyIpAddress.ts
@@ -11,7 +11,7 @@ import { VirtualMachineTreeItem } from '../tree/VirtualMachineTreeItem';
 
 export async function copyIpAddress(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.allOSContextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.allContextValue, context);
     }
 
     await vscode.env.clipboard.writeText(await node.getIpAddress());

--- a/src/commands/openInPortal.ts
+++ b/src/commands/openInPortal.ts
@@ -9,7 +9,7 @@ import { VirtualMachineTreeItem } from '../tree/VirtualMachineTreeItem';
 
 export async function openInPortal(context: IActionContext, node?: AzureTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<AzureTreeItem>(VirtualMachineTreeItem.allOSContextValue, context);
+        node = await ext.tree.showTreeItemPicker<AzureTreeItem>(VirtualMachineTreeItem.allContextValue, context);
     }
 
     await node.openInPortal();

--- a/src/commands/openInRemoteSsh.ts
+++ b/src/commands/openInRemoteSsh.ts
@@ -17,7 +17,7 @@ import { verifyRemoteSshExtension } from './verifyRemoteSshExtension';
 
 export async function openInRemoteSsh(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.linuxContextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(/^VirtualMachine.+linux.+running/, context);
     }
 
     await verifyRemoteSshExtension(context);

--- a/src/commands/restartVirtualMachine.ts
+++ b/src/commands/restartVirtualMachine.ts
@@ -13,7 +13,7 @@ import { nonNullValue } from "../utils/nonNull";
 
 export async function restartVirtualMachine(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.allContextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.runningContextValue, context);
     }
 
     const computeClient: ComputeManagementClient = await createComputeClient(node.root);

--- a/src/commands/restartVirtualMachine.ts
+++ b/src/commands/restartVirtualMachine.ts
@@ -13,7 +13,7 @@ import { nonNullValue } from "../utils/nonNull";
 
 export async function restartVirtualMachine(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.allOSContextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.allContextValue, context);
     }
 
     const computeClient: ComputeManagementClient = await createComputeClient(node.root);

--- a/src/commands/startVirtualMachine.ts
+++ b/src/commands/startVirtualMachine.ts
@@ -13,7 +13,7 @@ import { nonNullValue } from "../utils/nonNull";
 
 export async function startVirtualMachine(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.allOSContextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.stoppedContextValue, context);
     }
 
     const computeClient: ComputeManagementClient = await createComputeClient(node.root);

--- a/src/commands/stopVirtualMachine.ts
+++ b/src/commands/stopVirtualMachine.ts
@@ -13,7 +13,7 @@ import { nonNullValue } from "../utils/nonNull";
 
 export async function stopVirtualMachine(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.allOSContextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.runningContextValue, context);
     }
 
     const computeClient: ComputeManagementClient = await createComputeClient(node.root);

--- a/src/commands/viewProperties.ts
+++ b/src/commands/viewProperties.ts
@@ -9,7 +9,7 @@ import { VirtualMachineTreeItem } from '../tree/VirtualMachineTreeItem';
 
 export async function viewProperties(context: IActionContext, node?: VirtualMachineTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.allOSContextValue, context);
+        node = await ext.tree.showTreeItemPicker<VirtualMachineTreeItem>(VirtualMachineTreeItem.allContextValue, context);
     }
 
     await openReadOnlyJson(node, node.data);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,7 +54,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         registerCommand('azureVirtualMachines.restartVirtualMachine', restartVirtualMachine);
         registerCommand('azureVirtualMachines.stopVirtualMachine', stopVirtualMachine);
         registerCommand('azureVirtualMachines.addSshKey', addSshKey);
-        registerCommand('azureVirtualMachines.deleteVirtualMachine', async (actionContext: IActionContext, node?: SubscriptionTreeItem) => await deleteNode(actionContext, VirtualMachineTreeItem.allOSContextValue, node));
+        registerCommand('azureVirtualMachines.deleteVirtualMachine', async (actionContext: IActionContext, node?: SubscriptionTreeItem) => await deleteNode(actionContext, VirtualMachineTreeItem.allContextValue, node));
         registerCommand('azureVirtualMachines.copyIpAddress', copyIpAddress);
         registerCommand('azureVirtualMachines.viewProperties', viewProperties);
         registerCommand('azureVirtualMachines.openInRemoteSsh', openInRemoteSsh);

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -123,7 +123,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         const virtualMachine: ComputeManagementModels.VirtualMachine = nonNullProp(wizardContext, 'virtualMachine');
 
         const newVm: VirtualMachineTreeItem = new VirtualMachineTreeItem(this, virtualMachine, undefined /* assume all newly created VMs are running */);
-        if (newVm.contextValue === VirtualMachineTreeItem.linuxContextValue) {
+        if (VirtualMachineTreeItem.linuxContextValue.test(newVm.contextValue)) {
             await configureSshConfig(newVm, `~/.ssh/${wizardContext.sshKeyName}`);
         }
 

--- a/src/tree/VirtualMachineTreeItem.ts
+++ b/src/tree/VirtualMachineTreeItem.ts
@@ -15,6 +15,12 @@ import { nonNullProp, nonNullValueAndProp } from '../utils/nonNull';
 import { treeUtils } from '../utils/treeUtils';
 
 export class VirtualMachineTreeItem extends AzureTreeItem {
+    public static runningContextValue: RegExp = /^VirtualMachine.+running/;
+    public static stoppedContextValue: RegExp = /^VirtualMachine.+stopped/;
+    public static linuxContextValue: RegExp = /^VirtualMachine.+linux/;
+    public static windowsContextValue: RegExp = /^VirtualMachine.+windows/;
+    public static allContextValue: RegExp = /^VirtualMachine/;
+
     public get label(): string {
         return `${this.name}`;
     }
@@ -41,15 +47,17 @@ export class VirtualMachineTreeItem extends AzureTreeItem {
         return this._state?.toLowerCase() !== 'running' ? this._state : undefined;
     }
 
+    public get contextValue(): string {
+        const os: string = !!(this.data.osProfile?.linuxConfiguration) ? 'linux' : 'windows';
+        const state: string = this._state?.toLowerCase() === 'running' ? 'running' : 'stopped';
+
+        return `VirtualMachine-${os}-${state}`;
+    }
+
     public get data(): ComputeManagementModels.VirtualMachine {
         return this.virtualMachine;
     }
 
-    public static linuxContextValue: string = 'linuxVirtualMachine';
-    public static windowsContextValue: string = 'windowsVirtualMachine';
-    public static allOSContextValue: RegExp = /VirtualMachine$/;
-
-    public contextValue: string;
     public virtualMachine: ComputeManagementModels.VirtualMachine;
     private _state?: string;
 
@@ -57,7 +65,6 @@ export class VirtualMachineTreeItem extends AzureTreeItem {
         super(parent);
         this.virtualMachine = vm;
         this._state = instanceView ? this.getStateFromInstanceView(instanceView) : undefined;
-        this.contextValue = !!(vm.osProfile?.linuxConfiguration) ? VirtualMachineTreeItem.linuxContextValue : VirtualMachineTreeItem.windowsContextValue;
     }
 
     public getUser(): string {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/124

I think I could use some help here... I think that there should be an easier way to just construct the RegEx for the tree picker than manually typing everything out, but I don't know if that'd actually be a reliable type-casted solution.

I'm also concerned that the state might not always be accurate.  Theoretically, it should get updated whenever it refreshes, but I think there are times where it doesn't update to "running" right after a restart/start so this might be more trouble than it's worth.