### PR TITLE
Verify if VM was deleted before removing node from cache

### DIFF
--- a/src/commands/deleteVirtualMachine/deleteAllResources.ts
+++ b/src/commands/deleteVirtualMachine/deleteAllResources.ts
@@ -10,8 +10,8 @@ import { createResourceClient } from "../../utils/azureClients";
 import { networkInterfaceLabel, ResourceToDelete, virtualMachineLabel, virtualNetworkLabel } from "./deleteConstants";
 import { deleteWithOutput } from "./deleteWithOutput";
 
-export async function deleteAllResources(context: ISubscriptionContext, resourceGroupName: string, resourcesToDelete: ResourceToDelete[]): Promise<string[]> {
-    const failedResources: string[] = [];
+export async function deleteAllResources(context: ISubscriptionContext, resourceGroupName: string, resourcesToDelete: ResourceToDelete[]): Promise<ResourceToDelete[]> {
+    const failedResources: ResourceToDelete[] = [];
 
     // virtual machines have to be deleted before a lot of other resources so do it first
     // network interfaces have to be delete before public IP and virtual networks

--- a/src/commands/deleteVirtualMachine/deleteWithOutput.ts
+++ b/src/commands/deleteVirtualMachine/deleteWithOutput.ts
@@ -8,7 +8,7 @@ import { ext } from "../../extensionVariables";
 import { localize } from "../../localize";
 import { ResourceToDelete } from "./deleteConstants";
 
-export async function deleteWithOutput(resource: ResourceToDelete, errors: string[]): Promise<void> {
+export async function deleteWithOutput(resource: ResourceToDelete, errors: ResourceToDelete[]): Promise<void> {
     const deleting: string = localize('Deleting', 'Deleting {0} "{1}"...', resource.resourceType, resource.resourceName);
     const deleteSucceeded: string = localize('DeleteSucceeded', 'Successfully deleted {0} "{1}".', resource.resourceType, resource.resourceName);
 
@@ -17,7 +17,7 @@ export async function deleteWithOutput(resource: ResourceToDelete, errors: strin
         await resource.deleteMethod();
     } catch (error) {
         ext.outputChannel.appendLog(localize('deleteFailed', 'Deleting {0} "{1}" failed: {2}', resource.resourceType, resource.resourceName, parseError(error).message));
-        errors.push(resource.resourceName);
+        errors.push(resource);
         return;
     }
 

--- a/src/tree/VirtualMachineTreeItem.ts
+++ b/src/tree/VirtualMachineTreeItem.ts
@@ -97,8 +97,6 @@ export class VirtualMachineTreeItem extends AzureTreeItem {
             if (multiDelete) { ext.outputChannel.appendLog(deleting); }
 
             const failedResources: string[] = await deleteAllResources(this.root, this.resourceGroup, resourcesToDelete);
-            await ext.tree.refresh(context, this.parent);
-
             const messageDeleteWithErrors: string = localize(
                 'messageDeleteWithErrors',
                 `Failed to delete the following resources ${failedResources.join(', ')}.`);
@@ -109,9 +107,9 @@ export class VirtualMachineTreeItem extends AzureTreeItem {
             // single resources are already displayed in the output channel
             if (multiDelete) { ext.outputChannel.appendLog(failedResources.length > 0 ? messageDeleteWithErrors : deleteSucceeded); }
             if (failedResources.length > 0) {
-                context.errorHandling.suppressDisplay = true;
-                vscode.window.showErrorMessage(`${messageDeleteWithErrors} Check the [output channel](command:${ext.prefix}.showOutputChannel) for more information.`);
-                throw new Error(messageDeleteWithErrors);
+                ext.ui.showWarningMessage(`${messageDeleteWithErrors} Check the [output channel](command:${ext.prefix}.showOutputChannel) for more information.`);
+                ext.outputChannel.appendLog(messageDeleteWithErrors);
+                context.telemetry.properties.failedResources = failedResources.length.toString();
             } else {
                 vscode.window.showInformationMessage(deleteSucceeded);
             }

--- a/src/tree/VirtualMachineTreeItem.ts
+++ b/src/tree/VirtualMachineTreeItem.ts
@@ -97,6 +97,7 @@ export class VirtualMachineTreeItem extends AzureTreeItem {
             if (multiDelete) { ext.outputChannel.appendLog(deleting); }
 
             const failedResources: string[] = await deleteAllResources(this.root, this.resourceGroup, resourcesToDelete);
+            await ext.tree.refresh(context, this.parent);
 
             const messageDeleteWithErrors: string = localize(
                 'messageDeleteWithErrors',
@@ -107,7 +108,6 @@ export class VirtualMachineTreeItem extends AzureTreeItem {
 
             // single resources are already displayed in the output channel
             if (multiDelete) { ext.outputChannel.appendLog(failedResources.length > 0 ? messageDeleteWithErrors : deleteSucceeded); }
-
             if (failedResources.length > 0) {
                 context.errorHandling.suppressDisplay = true;
                 vscode.window.showErrorMessage(`${messageDeleteWithErrors} Check the [output channel](command:${ext.prefix}.showOutputChannel) for more information.`);
@@ -116,8 +116,6 @@ export class VirtualMachineTreeItem extends AzureTreeItem {
                 vscode.window.showInformationMessage(deleteSucceeded);
             }
         });
-
-        await ext.tree.refresh(context, this.parent);
     }
 
     public async refreshImpl(_context: IActionContext): Promise<void> {

--- a/src/tree/VirtualMachineTreeItem.ts
+++ b/src/tree/VirtualMachineTreeItem.ts
@@ -107,8 +107,8 @@ export class VirtualMachineTreeItem extends AzureTreeItem {
             // single resources are already displayed in the output channel
             if (multiDelete) { ext.outputChannel.appendLog(failedResources.length > 0 ? messageDeleteWithErrors : deleteSucceeded); }
             if (failedResources.length > 0) {
+                // tslint:disable-next-line: no-floating-promises
                 ext.ui.showWarningMessage(`${messageDeleteWithErrors} Check the [output channel](command:${ext.prefix}.showOutputChannel) for more information.`);
-                ext.outputChannel.appendLog(messageDeleteWithErrors);
                 context.telemetry.properties.failedResources = failedResources.length.toString();
             } else {
                 vscode.window.showInformationMessage(deleteSucceeded);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/202

It wasn't refreshing because we're throwing an error with failures.  I could make it a try/finally, but it should be safe to refresh immediately after awaiting the deleteAll function since that's when Azure reports that resources are deleted.