### PR TITLE
Properly parse failed resources error message

### DIFF
--- a/src/commands/deleteVirtualMachine/deleteConstants.ts
+++ b/src/commands/deleteVirtualMachine/deleteConstants.ts
@@ -24,6 +24,11 @@ export interface IDeleteChildImplContext extends IActionContext {
      * String of resources that are being deleted used for output
      */
     resourceList: string;
+
+    /**
+     * Flag to determine if the virtual machine is in the resourcesToDelete
+     */
+    deleteVm?: boolean;
 }
 
 export const networkInterfaceLabel: string = localize('networkInterface', 'network interface');

--- a/src/commands/deleteVirtualMachine/deleteVirtualMachine.ts
+++ b/src/commands/deleteVirtualMachine/deleteVirtualMachine.ts
@@ -33,10 +33,12 @@ export async function deleteVirtualMachine(context: IActionContext & Partial<IDe
 
     context.telemetry.properties.cancelStep = 'confirmation';
     await ext.ui.showWarningMessage(confirmMessage, { modal: true }, DialogResponses.deleteResponse, DialogResponses.cancel);
+    context.deleteVm = resourcesToDelete.some(v => v.data.resourceType === virtualMachineLabel);
+
     context.telemetry.properties.cancelStep = undefined;
 
     context.telemetry.properties.numOfResources = resourcesToDelete.length.toString();
-    context.telemetry.properties.deleteVm = String(resourcesToDelete.some(v => v.data.resourceType === virtualMachineLabel));
+    context.telemetry.properties.deleteVm = String(context.deleteVm);
 
     context.resourcesToDelete = resourcesToDelete.map(r => r.data);
     context.resourceList = resourceList;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurevirtualmachines/issues/207

I noticed while testing that if the vm wasn't one of the resources you were deleting, that it would not throw an error and thus, the node would disappear from the tree view.  By fixing that, users can't click into "View output" anymore, but I think it's worth the trade-off to not give them a mini heart-attack when they think their VM was just deleted on accident.

