### PR TITLE
Display locations properly for VMs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2557,9 +2557,9 @@
             }
         },
         "node_modules/css-what": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
-            "integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+            "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
             "dev": true,
             "engines": {
                 "node": ">= 6"
@@ -13395,9 +13395,9 @@
             }
         },
         "css-what": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
-            "integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+            "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
             "dev": true
         },
         "d": {

--- a/src/commands/createVirtualMachine/getAvailableVMLocations.ts
+++ b/src/commands/createVirtualMachine/getAvailableVMLocations.ts
@@ -14,9 +14,8 @@ export async function getAvailableVMLocations(context: IVirtualMachineWizardCont
     const resourceSkus: ComputeManagementModels.ResourceSkusResult = await computeClient.resourceSkus.list();
     return resourceSkus.
         filter(sku => sku.resourceType && sku.resourceType === 'virtualMachines')
-        .filter(sku => sku.name && sku.name === context.size)
+        .filter(sku => sku.name && sku.name === context.size && sku.locations?.length && sku.locations.length > 0)
         .filter(sku => sku.restrictions?.length === 0 || sku.restrictions?.find(rescriction => rescriction.type !== 'Location'))
-        .map(sku => {
-            return nonNullProp(sku, 'name');
-        });
+        .map(sku => nonNullProp(sku, 'locations'))
+        .reduce((list, loc) => list.concat(loc));
 }

--- a/src/commands/createVirtualMachine/getAvailableVMLocations.ts
+++ b/src/commands/createVirtualMachine/getAvailableVMLocations.ts
@@ -14,7 +14,7 @@ export async function getAvailableVMLocations(context: IVirtualMachineWizardCont
     const resourceSkus: ComputeManagementModels.ResourceSkusResult = await computeClient.resourceSkus.list();
     return resourceSkus.
         filter(sku => sku.resourceType && sku.resourceType === 'virtualMachines')
-        .filter(sku => sku.name && sku.name === context.size && sku.locations?.length && sku.locations.length > 0)
+        .filter(sku => sku.name && sku.name === context.size && sku.locations?.length)
         .filter(sku => sku.restrictions?.length === 0 || sku.restrictions?.find(rescriction => rescriction.type !== 'Location'))
         .map(sku => nonNullProp(sku, 'locations'))
         .reduce((list, loc) => list.concat(loc));

--- a/src/commands/createVirtualMachine/getAvailableVMLocations.ts
+++ b/src/commands/createVirtualMachine/getAvailableVMLocations.ts
@@ -14,7 +14,7 @@ export async function getAvailableVMLocations(context: IVirtualMachineWizardCont
     const resourceSkus: ComputeManagementModels.ResourceSkusResult = await computeClient.resourceSkus.list();
     return resourceSkus.
         filter(sku => sku.resourceType && sku.resourceType === 'virtualMachines')
-        .filter(sku => sku.name && sku.name === context.size && sku.locations?.length)
+        .filter(sku => sku.name && sku.name === context.size && sku.locations)
         .filter(sku => sku.restrictions?.length === 0 || sku.restrictions?.find(rescriction => rescriction.type !== 'Location'))
         .map(sku => nonNullProp(sku, 'locations'))
         .reduce((list, loc) => list.concat(loc));


### PR DESCRIPTION
I don't know if the properties returned from the API changed or if I was just always doing it wrong and never noticed but because I upgraded the UI package, all of the locations had disappeared from the list of quick picks.  I updated the logic and it looks good now.

For reference, the ResourceSku has a locations string[].

![image](https://user-images.githubusercontent.com/5290572/124337133-e96efc00-db55-11eb-935e-7f256edd9d02.png)
