### PR TITLE
Update SUSE and Windows 10 Pro images

### DIFF
--- a/src/commands/createVirtualMachine/ImageListStep.ts
+++ b/src/commands/createVirtualMachine/ImageListStep.ts
@@ -43,9 +43,9 @@ const linuxImages: ImageReferenceWithLabel[] = [
         version: 'latest'
     },
     {
-        label: 'SUSE Enterprise Linux 15 SP1 - Gen1',
+        label: 'SUSE Enterprise Linux 15 SP2 - Gen1',
         publisher: 'suse',
-        offer: 'sles-15-sp1-basic',
+        offer: 'sles-15-sp2-basic',
         sku: 'gen1',
         version: 'latest'
     },
@@ -109,9 +109,9 @@ const windowsImages: ImageReferenceWithLabel[] = [
         version: 'latest'
     },
     {
-        label: 'Windows 10 Pro, Version 1809 - Gen1',
+        label: 'Windows 10 Pro, Version 20H2 - Gen 1',
         publisher: 'MicrosoftWindowsDesktop',
         offer: 'Windows-10',
-        sku: 'rs5-pro',
+        sku: '20h2-pro',
         version: 'latest'
     }];


### PR DESCRIPTION
The image SKUs we had for SUSE and Windows 10 Pro were no longer working. I've updated them to the versions recommended in the portal.

I ran into this while writing tests for VMs. [Pipelines logs showing the failing images](https://dev.azure.com/ms-azuretools/AzCode/_build/results?buildId=37938&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=ad666c27-9912-565a-5bbd-35c171839ad6)

[Pipelines run with the updated images](https://dev.azure.com/ms-azuretools/AzCode/_build/results?buildId=38012&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=6e60e40e-3d3d-5182-ba10-afdf8e87d3dd&l=905)