### PR TITLE
Fix CredScan for test password

### DIFF
--- a/test/nightly/createVirtualMachine.test.ts
+++ b/test/nightly/createVirtualMachine.test.ts
@@ -28,7 +28,7 @@ suite("Create virtual machine", function (this: Mocha.Suite): void {
 
     this.timeout(8 * 60 * 1000);
 
-    const password = "password123!"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Password is fake and only used for tests.")]
+    const password = `${getRandomHexString(10)}123!`;
     const standardPasswordInput: IPasswordInput = {
         title: "standard password",
         input: [password, password]

--- a/test/nightly/createVirtualMachine.test.ts
+++ b/test/nightly/createVirtualMachine.test.ts
@@ -28,7 +28,7 @@ suite("Create virtual machine", function (this: Mocha.Suite): void {
 
     this.timeout(8 * 60 * 1000);
 
-    const password = "password123!";
+    const password = "password123!"; // [SuppressMessage("Microsoft.Security", "CS001:SecretInline", Justification="Password is fake and only used for tests.")]
     const standardPasswordInput: IPasswordInput = {
         title: "standard password",
         input: [password, password]


### PR DESCRIPTION
Suppress CredScan from picking up the fake password I'm using in the tests. 

Failing pipeline longs: https://dev.azure.com/ms-azuretools/AzCode/_build/results?buildId=38493&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=0aa8275a-6ca1-5a5e-7320-e99615c20d24