### PR TITLE
Better error message for EdgeZone unfriendly images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.5.0 - 2022-01-25
 
-## Added
+### Added
 - Support for creating Virtual Machines in extended regions using Advanced create.
 
 ## 0.4.1 - 2021-08-24

--- a/src/commands/createVirtualMachine/PublicIpCreateStep.ts
+++ b/src/commands/createVirtualMachine/PublicIpCreateStep.ts
@@ -38,7 +38,14 @@ export class PublicIpCreateStep extends AzureWizardExecuteStep<IVirtualMachineWi
         progress.report({ message: creatingIp });
         ext.outputChannel.appendLog(creatingIp);
 
-        context.publicIpAddress = await networkClient.publicIPAddresses.createOrUpdate(rgName, ipName, publicIpProps);
+        try {
+            context.publicIpAddress = await networkClient.publicIPAddresses.createOrUpdate(rgName, ipName, publicIpProps);
+        } catch (e) {
+            if (extendedLocation) {
+                throw new Error(localize('mayNotBeSupportedInEdgeZones', 'Failed to create Virtual Machine. This image may not be supported in Edge Zones.'))
+            }
+            throw e;
+        }
         ext.outputChannel.appendLog(localize('creatingIp', `Created new public IP addresss "${ipName}".`));
     }
 


### PR DESCRIPTION
Nathan and I decided we should at least do this to remedy #292

Here is the more friendly error:
![image](https://user-images.githubusercontent.com/12476526/151074605-8f0a8bf4-3bd6-45e4-bcab-7534d614359a.png)

Edit: verified this works on all the images that were incompatible.