### PR TITLE
Fix expected child context values

### DIFF
--- a/src/commands/addSshKey.ts
+++ b/src/commands/addSshKey.ts
@@ -18,8 +18,13 @@ export async function addSshKey(context: IActionContext, node?: ResolvedVirtualM
     if (!node) {
         node = await ext.rgApi.pickAppResource<ResolvedVirtualMachineTreeItem>(context, {
             filter: vmFilter,
-            expectedChildContextValue: new RegExp(VirtualMachineTreeItem.linuxContextValue)
+            // TODO: only show Linux VMs
+            // expectedChildContextValue: new RegExp(VirtualMachineTreeItem.linuxContextValue)
         });
+
+        if (!node.contextValue.includes(VirtualMachineTreeItem.linuxContextValue)) {
+            throw new Error(localize('addSshKeyNotLinux', 'Only Linux VMs are supported.'));
+        }
     }
 
     if (!node) {

--- a/src/commands/copyIpAddress.ts
+++ b/src/commands/copyIpAddress.ts
@@ -8,13 +8,12 @@ import * as vscode from 'vscode';
 import { vmFilter } from '../constants';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
-import { ResolvedVirtualMachineTreeItem, VirtualMachineTreeItem } from '../tree/VirtualMachineTreeItem';
+import { ResolvedVirtualMachineTreeItem } from '../tree/VirtualMachineTreeItem';
 
 export async function copyIpAddress(context: IActionContext, node?: ResolvedVirtualMachineTreeItem): Promise<void> {
     if (!node) {
         node = await ext.rgApi.pickAppResource<ResolvedVirtualMachineTreeItem>(context, {
             filter: vmFilter,
-            expectedChildContextValue: new RegExp(VirtualMachineTreeItem.allOSContextValue)
         });
     }
 

--- a/src/commands/deleteVirtualMachine/deleteVirtualMachine.ts
+++ b/src/commands/deleteVirtualMachine/deleteVirtualMachine.ts
@@ -6,14 +6,13 @@
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import { vmFilter } from "../../constants";
 import { ext } from "../../extensionVariables";
-import { ResolvedVirtualMachineTreeItem, VirtualMachineTreeItem } from "../../tree/VirtualMachineTreeItem";
+import { ResolvedVirtualMachineTreeItem } from "../../tree/VirtualMachineTreeItem";
 import { IDeleteChildImplContext } from "./deleteConstants";
 
 export async function deleteVirtualMachine(context: IActionContext & Partial<IDeleteChildImplContext>, node?: ResolvedVirtualMachineTreeItem): Promise<void> {
     if (!node) {
         node = await ext.rgApi.pickAppResource<ResolvedVirtualMachineTreeItem>({ ...context, suppressCreatePick: true }, {
             filter: vmFilter,
-            expectedChildContextValue: new RegExp(VirtualMachineTreeItem.allOSContextValue)
         });
     }
     // context.telemetry.properties.numOfResources = resourcesToDelete.length.toString();

--- a/src/commands/openInRemoteSsh.ts
+++ b/src/commands/openInRemoteSsh.ts
@@ -19,8 +19,13 @@ export async function openInRemoteSsh(context: IActionContext & { canPickMany?: 
     if (!node) {
         node = await ext.rgApi.pickAppResource<ResolvedVirtualMachineTreeItem>(context, {
             filter: vmFilter,
-            expectedChildContextValue: new RegExp(VirtualMachineTreeItem.linuxContextValue)
+            // TODO: only show Linux VMs
+            // expectedChildContextValue: new RegExp(VirtualMachineTreeItem.linuxContextValue)
         });
+
+        if (!node.contextValue.includes(VirtualMachineTreeItem.linuxContextValue)) {
+            throw new Error(localize('addSshKeyNotLinux', 'Only Linux VMs are supported.'));
+        }
     }
 
     await verifyRemoteSshExtension(context);

--- a/src/commands/restartVirtualMachine.ts
+++ b/src/commands/restartVirtualMachine.ts
@@ -8,14 +8,13 @@ import { IActionContext, nonNullValue } from "@microsoft/vscode-azext-utils";
 import { vmFilter } from "../constants";
 import { ext } from "../extensionVariables";
 import { localize } from "../localize";
-import { ResolvedVirtualMachineTreeItem, VirtualMachineTreeItem } from "../tree/VirtualMachineTreeItem";
+import { ResolvedVirtualMachineTreeItem } from "../tree/VirtualMachineTreeItem";
 import { createComputeClient } from "../utils/azureClients";
 
 export async function restartVirtualMachine(context: IActionContext, node?: ResolvedVirtualMachineTreeItem): Promise<void> {
     if (!node) {
         node = await ext.rgApi.pickAppResource<ResolvedVirtualMachineTreeItem>(context, {
             filter: vmFilter,
-            expectedChildContextValue: new RegExp(VirtualMachineTreeItem.allOSContextValue)
         });
     }
 

--- a/src/commands/startVirtualMachine.ts
+++ b/src/commands/startVirtualMachine.ts
@@ -8,14 +8,13 @@ import { IActionContext, nonNullValue } from "@microsoft/vscode-azext-utils";
 import { vmFilter } from "../constants";
 import { ext } from "../extensionVariables";
 import { localize } from "../localize";
-import { ResolvedVirtualMachineTreeItem, VirtualMachineTreeItem } from "../tree/VirtualMachineTreeItem";
+import { ResolvedVirtualMachineTreeItem } from "../tree/VirtualMachineTreeItem";
 import { createComputeClient } from "../utils/azureClients";
 
 export async function startVirtualMachine(context: IActionContext, node?: ResolvedVirtualMachineTreeItem): Promise<void> {
     if (!node) {
         node = await ext.rgApi.pickAppResource<ResolvedVirtualMachineTreeItem>(context, {
             filter: vmFilter,
-            expectedChildContextValue: new RegExp(VirtualMachineTreeItem.allOSContextValue)
         });
     }
 

--- a/src/commands/stopVirtualMachine.ts
+++ b/src/commands/stopVirtualMachine.ts
@@ -8,14 +8,13 @@ import { IActionContext, nonNullValue } from "@microsoft/vscode-azext-utils";
 import { vmFilter } from "../constants";
 import { ext } from "../extensionVariables";
 import { localize } from "../localize";
-import { ResolvedVirtualMachineTreeItem, VirtualMachineTreeItem } from "../tree/VirtualMachineTreeItem";
+import { ResolvedVirtualMachineTreeItem } from "../tree/VirtualMachineTreeItem";
 import { createComputeClient } from "../utils/azureClients";
 
 export async function stopVirtualMachine(context: IActionContext, node?: ResolvedVirtualMachineTreeItem): Promise<void> {
     if (!node) {
         node = await ext.rgApi.pickAppResource<ResolvedVirtualMachineTreeItem>(context, {
             filter: vmFilter,
-            expectedChildContextValue: new RegExp(VirtualMachineTreeItem.allOSContextValue)
         });
     }
 


### PR DESCRIPTION
Fixes #372 

I'm back with another expectedChildContextValue fix. This time however, `expectedChildContextValue` was actually being used to filter the top level resources to only Linux VMs for two commands.

As a temporary fix until VMs is rewritten fully, I've removed the filtering, and added an error that throws if the user picks a non-Linux VM for these commands.

I think VMs is a prime candidate to get rewritten soon since it's small, so I'm ok with this less than ideal fix. In order to get all the commands to work, we need to sacrifice a bit of UX for these commands.