### PR TITLE
Implement activity log to create and delete virtual machines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
             },
             "devDependencies": {
                 "@microsoft/eslint-config-azuretools": "^0.2.2",
-                "@microsoft/vscode-azext-dev": "^2.0.0",
+                "@microsoft/vscode-azext-dev": "^2.0.4",
                 "@types/fs-extra": "^8.1.1",
                 "@types/gulp": "^4.0.8",
                 "@types/mocha": "^8.2.2",
@@ -609,9 +609,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-dev": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-dev/-/vscode-azext-dev-2.0.0.tgz",
-            "integrity": "sha512-fnj7UqLAHgLgLewPixzU4s20W+cEFHdLQ0CXsgCDdwQ2zw8ToyB9bn9HGr93UfWvQtktCPaPDgUmwXWpdd9ocg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-dev/-/vscode-azext-dev-2.0.4.tgz",
+            "integrity": "sha512-+XZenjPrfsEc3OPMOdPBVCgPsTvx6h1BVItf5mUoRC3lfN3Gv8OZF80VIETnC9Gj5nB+9nDpQWDzj9V/+2ZS/g==",
             "dev": true,
             "dependencies": {
                 "assert": "^2.0.0",
@@ -11876,9 +11876,9 @@
             }
         },
         "@microsoft/vscode-azext-dev": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-dev/-/vscode-azext-dev-2.0.0.tgz",
-            "integrity": "sha512-fnj7UqLAHgLgLewPixzU4s20W+cEFHdLQ0CXsgCDdwQ2zw8ToyB9bn9HGr93UfWvQtktCPaPDgUmwXWpdd9ocg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-dev/-/vscode-azext-dev-2.0.4.tgz",
+            "integrity": "sha512-+XZenjPrfsEc3OPMOdPBVCgPsTvx6h1BVItf5mUoRC3lfN3Gv8OZF80VIETnC9Gj5nB+9nDpQWDzj9V/+2ZS/g==",
             "dev": true,
             "requires": {
                 "assert": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     },
     "devDependencies": {
         "@microsoft/eslint-config-azuretools": "^0.2.2",
-        "@microsoft/vscode-azext-dev": "^2.0.0",
+        "@microsoft/vscode-azext-dev": "^2.0.4",
         "@types/fs-extra": "^8.1.1",
         "@types/gulp": "^4.0.8",
         "@types/mocha": "^8.2.2",

--- a/src/commands/AzureWizardActivityOutputExecuteStep.ts
+++ b/src/commands/AzureWizardActivityOutputExecuteStep.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { activityFailContext, activityFailIcon, activityProgressContext, activityProgressIcon, activitySuccessContext, activitySuccessIcon, AzureWizardExecuteStep, createUniversallyUniqueContextValue, GenericTreeItem, type ExecuteActivityOutput, type IActionContext } from "@microsoft/vscode-azext-utils";
+import { activityFailContext, activityFailIcon, activityProgressContext, activityProgressIcon, activitySuccessContext, activitySuccessIcon, AzureWizardExecuteStep, createUniversallyUniqueContextValue, GenericParentTreeItem, GenericTreeItem, type ExecuteActivityOutput, type IActionContext } from "@microsoft/vscode-azext-utils";
 
 export abstract class AzureWizardActivityOutputExecuteStep<T extends IActionContext> extends AzureWizardExecuteStep<T> {
     protected abstract getSuccessString(context: T): string;
@@ -47,12 +47,21 @@ function createExecuteActivityOutput(context: IActionContext, options: {
     const label = options.label;
     const iconPath = options.activityStatus === 'Success' ? activitySuccessIcon : options.activityStatus === 'Fail' ? activityFailIcon : activityProgressIcon;
 
-    return {
-        item: new GenericTreeItem(undefined, {
+    const item = options.activityStatus === 'Fail' ?
+        // there is logic that will automatically tack on error items as children if thrown in that step so return a parent tree item
+        new GenericParentTreeItem(undefined, {
             contextValue,
             label,
             iconPath
-        }),
+        }) :
+        new GenericTreeItem(undefined, {
+            contextValue,
+            label,
+            iconPath
+        });
+
+    return {
+        item,
         message: options.label
     }
 }

--- a/src/commands/AzureWizardActivityOutputExecuteStep.ts
+++ b/src/commands/AzureWizardActivityOutputExecuteStep.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { activityFailContext, activityFailIcon, activityProgressContext, activityProgressIcon, activitySuccessContext, activitySuccessIcon, AzureWizardExecuteStep, createUniversallyUniqueContextValue, GenericTreeItem, type ExecuteActivityOutput, type IActionContext } from "@microsoft/vscode-azext-utils";
+
+export abstract class AzureWizardActivityOutputExecuteStep<T extends IActionContext> extends AzureWizardExecuteStep<T> {
+    protected abstract getSuccessString(context: T): string;
+    protected abstract getProgressString(context: T): string;
+    protected abstract getFailString(context: T): string;
+    abstract stepName: string;
+
+    public createSuccessOutput(context: T): ExecuteActivityOutput {
+        return createExecuteActivityOutput(context, {
+            activityStatus: 'Success',
+            label: this.getSuccessString(context),
+            stepName: this.stepName
+        });
+    }
+
+    public createProgressOutput(context: T): ExecuteActivityOutput {
+        return createExecuteActivityOutput(context, {
+            activityStatus: 'Progress',
+            label: this.getProgressString(context),
+            stepName: this.stepName
+        });
+    }
+
+    public createFailOutput(context: T): ExecuteActivityOutput {
+        return createExecuteActivityOutput(context, {
+            activityStatus: 'Fail',
+            label: this.getFailString(context),
+            stepName: this.stepName
+        });
+    }
+
+}
+
+function createExecuteActivityOutput(context: IActionContext, options: {
+    stepName: string
+    activityStatus: 'Success' | 'Fail' | 'Progress',
+    label: string
+}): ExecuteActivityOutput {
+    const activityContext = options.activityStatus === 'Success' ? activitySuccessContext : options.activityStatus === 'Fail' ? activityFailContext : activityProgressContext;
+    const contextValue = createUniversallyUniqueContextValue([`nsgCreateStep${options.activityStatus}Item`, activityContext]);
+    const label = options.label;
+    const iconPath = options.activityStatus === 'Success' ? activitySuccessIcon : options.activityStatus === 'Fail' ? activityFailIcon : activityProgressIcon;
+
+    return {
+        item: new GenericTreeItem(undefined, {
+            contextValue,
+            label,
+            iconPath
+        }),
+        message: options.label
+    }
+}

--- a/src/commands/createVirtualMachine/createVirtualMachine.ts
+++ b/src/commands/createVirtualMachine/createVirtualMachine.ts
@@ -38,6 +38,8 @@ export async function createVirtualMachine(context: IActionContext & Partial<ICr
         ...(await createActivityContext())
     });
 
+    wizardContext.activityChildren = [];
+
     const computeProvider: string = 'Microsoft.Compute';
     LocationListStep.setLocationSubset(wizardContext, getAvailableVMLocations(wizardContext), computeProvider);
 

--- a/src/commands/createVirtualMachine/createVirtualMachine.ts
+++ b/src/commands/createVirtualMachine/createVirtualMachine.ts
@@ -35,10 +35,8 @@ export async function createVirtualMachine(context: IActionContext & Partial<ICr
         addressPrefix: '10.1.0.0/24',
         size,
         includeExtendedLocations: true,
-        ...(await createActivityContext())
+        ...(await createActivityContext(true))
     });
-
-    wizardContext.activityChildren = [];
 
     const computeProvider: string = 'Microsoft.Compute';
     LocationListStep.setLocationSubset(wizardContext, getAvailableVMLocations(wizardContext), computeProvider);

--- a/src/commands/deleteVirtualMachine/ConfirmDeleteStep.ts
+++ b/src/commands/deleteVirtualMachine/ConfirmDeleteStep.ts
@@ -26,7 +26,6 @@ export class ConfirmDeleteStep extends AzureWizardPromptStep<IDeleteChildImplCon
         context.telemetry.properties.deleteVm = String(deleteVm);
     }
 
-
     public shouldPrompt(): boolean {
         return true;
     }

--- a/src/commands/deleteVirtualMachine/DeleteVirtualMachineStep.ts
+++ b/src/commands/deleteVirtualMachine/DeleteVirtualMachineStep.ts
@@ -3,16 +3,18 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizardExecuteStep, nonNullProp, type AzExtErrorButton } from "@microsoft/vscode-azext-utils";
+import { nonNullProp, type AzExtErrorButton } from "@microsoft/vscode-azext-utils";
 import { type Progress } from "vscode";
 import { viewOutput, virtualMachineLabel } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../localize";
+import { AzureWizardActivityOutputExecuteStep } from "../AzureWizardActivityOutputExecuteStep";
 import { deleteAllResources } from "./deleteAllResources";
 import { type IDeleteChildImplContext, type ResourceToDelete } from "./deleteConstants";
 
-export class DeleteVirtualMachineStep extends AzureWizardExecuteStep<IDeleteChildImplContext> {
+export class DeleteVirtualMachineStep extends AzureWizardActivityOutputExecuteStep<IDeleteChildImplContext> {
     public priority: number = 100;
+    stepName: string = 'deleteVirtualMachineStep';
 
     public async execute(context: IDeleteChildImplContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined; }>): Promise<void> {
 
@@ -58,5 +60,17 @@ export class DeleteVirtualMachineStep extends AzureWizardExecuteStep<IDeleteChil
 
     public shouldExecute(): boolean {
         return true;
+    }
+
+    protected getSuccessString(context: IDeleteChildImplContext): string {
+        return localize('deletedVm', 'Deleted virtual machine "{0}".', context.resourceList);
+    }
+
+    protected getProgressString(context: IDeleteChildImplContext): string {
+        return localize('deletingVm', 'Deleting virtual machine "{0}"...', context.resourceList);
+    }
+
+    protected getFailString(context: IDeleteChildImplContext): string {
+        return this.getSuccessString(context);
     }
 }

--- a/src/tree/VirtualMachineTreeItem.ts
+++ b/src/tree/VirtualMachineTreeItem.ts
@@ -111,7 +111,7 @@ export class VirtualMachineTreeItem implements ResolvedVirtualMachine {
 
         const wizardContext: IDeleteChildImplContext = Object.assign(context, {
             node: this as ResolvedVirtualMachineTreeItem,
-            ...(await createActivityContext()),
+            ...(await createActivityContext(true)),
         });
 
         const wizard = new AzureWizard<IDeleteChildImplContext>(wizardContext, {

--- a/src/utils/activityUtils.ts
+++ b/src/utils/activityUtils.ts
@@ -7,9 +7,10 @@ import { type ExecuteActivityContext } from "@microsoft/vscode-azext-utils";
 import { ext } from "../extensionVariables";
 import { getWorkspaceSetting } from "../vsCodeConfig/settings";
 
-export async function createActivityContext(): Promise<ExecuteActivityContext> {
+export async function createActivityContext(withChildren?: boolean): Promise<ExecuteActivityContext> {
     return {
         registerActivity: async (activity) => ext.rgApi.registerActivity(activity),
         suppressNotification: await getWorkspaceSetting('suppressActivityNotifications', undefined, 'azureResourceGroups'),
+        activityChildren: withChildren ? [] : undefined
     };
 }


### PR DESCRIPTION
Relies on https://github.com/microsoft/vscode-azuretools/pull/1767

This is just an idea of how we could implement this across other extensions. We could move the step I made or leave it to the extension to figure out how they want to implement all of this activity log shenanigans.

Let me know if you have any thoughts on other ways we could make it easier to implement, whether it's shared in the npm package or if there's something I did weird/stupid in this PR.

An example of what it looks like in action:
![image](https://github.com/user-attachments/assets/f2fa8083-56ed-4e90-a906-d5b2cb20c4ac)
